### PR TITLE
[Fix] sync-fork 403 권한 오류 수정

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure git identity
         run: |
@@ -28,7 +29,7 @@ jobs:
 
       - name: Push to fork (mirror main)
         run: |
-          git push forked-repo main --force-with-lease
+          git push forked-repo HEAD:main --force-with-lease
 
       - name: Clean up
         if: always()


### PR DESCRIPTION
## 📌 Summary

> #18 
sync-fork 403 권한 오류 수정

## 📚 Tasks
`sync-fork.yml` 에서 포크 레포로 push 시 403 권한 오류가 발생해, 깃허브 기본 토큰이 아닌 PAT를 사용하도록 인증 방식을 수정합니다.

## 🔍 Describe
기존 워크플로우에서 포크 레포로 push할 때 깃허브 기본 토큰으로 인증이 잡히며 403 에러가 발생했습니다.
이를 방지하기 위해 `persist-credentials: false` 로 기본 credentials 사용을 차단하고, PAT를 통해서만 인증되도록 했습니다.


## 👀 To Reviewer
머지 후 진짜 최종 배포 테스트 진행합니다...


<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
