### PR TITLE
Fix(ads): icon export 경로 추가

### DIFF
--- a/packages/ads-ui/package.json
+++ b/packages/ads-ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "exports": {
     ".": "./src/components/index.ts",
+    "./icons": "./src/icons/index.ts",
     "./styles": "./src/styles/index.ts",
     "./styles/theme.css": "./src/styles/theme.css.ts"
   },


### PR DESCRIPTION
## 📌 Summary

> #84 
package 내부 package.json에 icon export 경로를 추가합니다.

## 📚 Tasks
package 내부 package.json에 icon export 경로를 추가합니다.

## 🔍 Describe
apps에서 SVGR을 import할 때 루트 경로가 node_modules로 잡히는 오류가 있었어요.
package 내부 exports에 `"./icons"` 추가해 딥 임포트를 방지했습니다. 
```tsx
import { ShareIcon } from '@amp/ads-ui/icons';
```
이렇게 사용하시면 됩니다!

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 아이콘 모듈을 별도로 임포트할 수 있는 새로운 내보내기 진입점이 추가되었습니다. 이를 통해 사용자는 더 유연한 방식으로 아이콘에 접근할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->