### PR TITLE
Refactor(audience): 관람한 공연 API 연동 추가

### DIFF
--- a/apps/audience/src/features/mypage/apis/query.ts
+++ b/apps/audience/src/features/mypage/apis/query.ts
@@ -4,14 +4,24 @@ import { get } from '@amp/apis';
 
 import { END_POINT } from '@shared/constants/end-point';
 import { USERS_QUERY_KEY } from '@shared/constants/query-key';
+import { ViewedFestivalsData } from '@shared/hooks/viewed-festival';
 import type { MyPageResponse } from '@shared/types/mypage-response';
 
 export const getMyPage = () => get<MyPageResponse>(END_POINT.GET_MY_PAGE);
+
+export const getViewedFestivals = () =>
+  get<ViewedFestivalsData>(END_POINT.GET_VIEWED_FESTIVALS);
 
 export const MY_PAGE_QUERY_OPTIONS = {
   MY_PAGE: () =>
     queryOptions({
       queryKey: USERS_QUERY_KEY.MY_PAGE(),
       queryFn: () => getMyPage(),
+    }),
+
+  VIEWED_FESTIVALS: () =>
+    queryOptions({
+      queryKey: USERS_QUERY_KEY.HOME_FESTIVALS_VIEWED(),
+      queryFn: () => getViewedFestivals(),
     }),
 } as const;

--- a/apps/audience/src/pages/my-events/my-events.tsx
+++ b/apps/audience/src/pages/my-events/my-events.tsx
@@ -1,13 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
 import { EmptyView } from '@amp/ads-ui';
 
 import FestivalList from '@widgets/my-events/festival-list';
 
-import { myEventsData } from '@shared/mocks/my-events-data';
+import { MY_PAGE_QUERY_OPTIONS } from '@features/mypage/apis/query';
 
 import * as styles from './my-events.css';
 
 const MyEventsPage = () => {
-  if (myEventsData.festivals.length === 0) {
+  const { data } = useQuery(MY_PAGE_QUERY_OPTIONS.VIEWED_FESTIVALS());
+
+  const festivals = data?.festivals ?? [];
+
+  if (festivals.length === 0) {
     return (
       <section className={styles.page}>
         <div className={styles.empty}>
@@ -20,7 +26,7 @@ const MyEventsPage = () => {
   return (
     <section className={styles.page}>
       <div className={styles.list}>
-        <FestivalList festivals={myEventsData.festivals} />
+        <FestivalList festivals={festivals} />
       </div>
     </section>
   );

--- a/apps/audience/src/shared/constants/end-point.ts
+++ b/apps/audience/src/shared/constants/end-point.ts
@@ -46,4 +46,7 @@ export const END_POINT = {
   GET_NOTIFICATIONS: '/users/notifications',
   POST_NOTIFICATIONS: (notificationId: number) =>
     `users/notifications/${notificationId}/read`,
+
+  // 마이페이지 관람 공연
+  GET_VIEWED_FESTIVALS: '/users/me/festivals/all',
 } as const;

--- a/apps/audience/src/shared/constants/query-key.ts
+++ b/apps/audience/src/shared/constants/query-key.ts
@@ -52,4 +52,9 @@ export const USERS_QUERY_KEY = {
   SAVED_NOTICES: () => [...USERS_QUERY_KEY.ALL, 'saved-notices'],
 
   NOTIFICATIONS: () => ['notifications'],
+
+  HOME_FESTIVALS_VIEWED: () => [
+    ...USERS_QUERY_KEY.ALL,
+    'home-festivals-viewed',
+  ],
 } as const;

--- a/apps/audience/src/shared/hooks/viewed-festival.ts
+++ b/apps/audience/src/shared/hooks/viewed-festival.ts
@@ -1,0 +1,28 @@
+export interface ViewedFestival {
+  festivalId: number;
+  title: string;
+  mainImageUrl: string;
+  period: string;
+  status: '관람 중' | '관람 예정' | '관람 완료';
+  wishList: boolean;
+}
+
+export interface Pagination {
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}
+
+export interface ViewedFestivalsData {
+  festivals: ViewedFestival[];
+  pagination: Pagination;
+}
+
+export interface ViewedFestivalsResponse {
+  status: number;
+  msg: string;
+  data: ViewedFestivalsData;
+}

--- a/apps/audience/src/widgets/my-events/festival-list.tsx
+++ b/apps/audience/src/widgets/my-events/festival-list.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 
 import { CardFestival, Chip } from '@amp/ads-ui';
 
-type MyEventsStatus = '관람 중' | '관람 예정';
+type MyEventsStatus = '관람 중' | '관람 예정' | '관람 완료';
 
 interface FestivalItem {
   festivalId: number;
@@ -19,8 +19,13 @@ const STATUS_CHIP: Record<MyEventsStatus, ReactElement> = {
     </Chip>
   ),
   '관람 예정': (
-    <Chip variant='status' status='upcoming'>
+    <Chip variant='status' status='dday'>
       관람 예정
+    </Chip>
+  ),
+  '관람 완료': (
+    <Chip variant='status' status='upcoming'>
+      관람 완료
     </Chip>
   ),
 };


### PR DESCRIPTION
## 📌 Summary

- #260 

목데이터 제거 후 관람한 공연 API 연동으로 대체

## 📚 Tasks

- 목데이터 제거
- 관람한 공연 API 연동

## 🔍 Describe

- 관람한 공연 API 연동 후 목데이터 대체

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
