### PR TITLE
Refactor(apps): 공지 뷰 하단 그라데이션 이슈 해결

### DIFF
--- a/apps/host/src/pages/home/home.css.ts
+++ b/apps/host/src/pages/home/home.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const page = style({
   minHeight: '100dvh',
-  paddingBottom: '8rem',
+  paddingBottom: '11rem',
 });
 
 export const content = style({

--- a/apps/host/src/pages/home/home.css.ts
+++ b/apps/host/src/pages/home/home.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 export const page = style({
   minHeight: '100dvh',
-  paddingBottom: '11rem',
+  paddingBottom: 'calc(11rem + env(safe-area-inset-bottom))',
 });
 
 export const content = style({

--- a/apps/host/src/pages/notice-create/notice-create.css.ts
+++ b/apps/host/src/pages/notice-create/notice-create.css.ts
@@ -7,7 +7,7 @@ export const container = style({
   flexDirection: 'column',
   gap: '2rem',
   margin: '3.1rem 2rem 0 2rem',
-  paddingBottom: '14rem',
+  paddingBottom: 'calc(14rem + env(safe-area-inset-bottom))',
 });
 
 export const titleContainer = style({
@@ -51,7 +51,7 @@ export const divider = style({
 });
 
 export const buttonContainer = style({
-  padding: '2rem',
+  padding: '2rem 2rem calc(2rem + env(safe-area-inset-bottom))',
 });
 
 export const chipContainer = style({

--- a/apps/host/src/pages/notice-create/notice-create.css.ts
+++ b/apps/host/src/pages/notice-create/notice-create.css.ts
@@ -7,7 +7,7 @@ export const container = style({
   flexDirection: 'column',
   gap: '2rem',
   margin: '3.1rem 2rem 0 2rem',
-  paddingBottom: '9rem',
+  paddingBottom: '14rem',
 });
 
 export const titleContainer = style({
@@ -51,14 +51,7 @@ export const divider = style({
 });
 
 export const buttonContainer = style({
-  position: 'fixed',
-  bottom: 0,
-  width: '100%',
-  maxWidth: '430px',
   padding: '2rem',
-  left: '50%',
-  transform: 'translateX(-50%)',
-  backgroundColor: ampThemeVars.color.gray_000,
 });
 
 export const chipContainer = style({

--- a/apps/host/src/pages/notice-create/notice-create.tsx
+++ b/apps/host/src/pages/notice-create/notice-create.tsx
@@ -10,7 +10,7 @@ import {
   Textfield,
 } from '@amp/ads-ui';
 import { PinIcon } from '@amp/ads-ui/icons';
-import { Loading } from '@amp/compositions';
+import { ButtonGradientSection, Loading } from '@amp/compositions';
 
 import { NOTICE_QUERY_OPTIONS } from '@features/notice/apis/query';
 import { NOTICES_QUERY_OPTIONS } from '@features/notice-list/apis/query';
@@ -214,7 +214,7 @@ const NoticeCreateForm = ({
           />
         </InputLayout>
 
-        <div className={styles.buttonContainer}>
+        <ButtonGradientSection className={styles.buttonContainer}>
           <CtaButton
             type='common'
             htmlType='submit'
@@ -223,7 +223,7 @@ const NoticeCreateForm = ({
           >
             완료
           </CtaButton>
-        </div>
+        </ButtonGradientSection>
       </form>
     </>
   );

--- a/apps/host/src/widgets/event-form/event-form.css.ts
+++ b/apps/host/src/widgets/event-form/event-form.css.ts
@@ -11,15 +11,11 @@ export const pageContainer = style({
 export const scrollArea = style({
   display: 'flex',
   flexDirection: 'column',
+  paddingBottom: '10rem',
 });
 
 export const bottom = style({
-  position: 'sticky',
-  bottom: 0,
-  left: 0,
-  right: 0,
-  padding: '1.7rem 0',
-  backgroundColor: ampThemeVars.color.gray_000,
+  padding: '1.7rem 2rem',
 });
 
 export const sectionText = recipe({

--- a/apps/host/src/widgets/event-form/event-form.css.ts
+++ b/apps/host/src/widgets/event-form/event-form.css.ts
@@ -14,7 +14,7 @@ export const scrollArea = style({
   paddingBottom: '10rem',
 });
 
-export const bottom = style({
+export const bottomContainer = style({
   padding: '1.7rem 2rem',
 });
 

--- a/apps/host/src/widgets/event-form/event-form.css.ts
+++ b/apps/host/src/widgets/event-form/event-form.css.ts
@@ -11,11 +11,11 @@ export const pageContainer = style({
 export const scrollArea = style({
   display: 'flex',
   flexDirection: 'column',
-  paddingBottom: '10rem',
+  paddingBottom: 'calc(10rem + env(safe-area-inset-bottom))',
 });
 
 export const bottomContainer = style({
-  padding: '1.7rem 2rem',
+  padding: '1.7rem 2rem calc(1.7rem + env(safe-area-inset-bottom))',
 });
 
 export const sectionText = recipe({

--- a/apps/host/src/widgets/event-form/event-form.tsx
+++ b/apps/host/src/widgets/event-form/event-form.tsx
@@ -288,7 +288,7 @@ const EventForm = ({
           />
         </section>
 
-        <ButtonGradientSection className={styles.bottom}>
+        <ButtonGradientSection className={styles.bottomContainer}>
           <CtaButton
             type='common'
             htmlType='submit'

--- a/apps/host/src/widgets/event-form/event-form.tsx
+++ b/apps/host/src/widgets/event-form/event-form.tsx
@@ -8,6 +8,7 @@ import {
   PlusIcon,
   TimeIcon,
 } from '@amp/ads-ui/icons';
+import { ButtonGradientSection } from '@amp/compositions';
 
 import useItemList from '@shared/hooks/use-item-list/use-item-list';
 import useObjectUrl from '@shared/hooks/use-object-url/use-object-url';
@@ -287,7 +288,7 @@ const EventForm = ({
           />
         </section>
 
-        <section className={styles.bottom}>
+        <ButtonGradientSection className={styles.bottom}>
           <CtaButton
             type='common'
             htmlType='submit'
@@ -296,7 +297,7 @@ const EventForm = ({
           >
             {submitText}
           </CtaButton>
-        </section>
+        </ButtonGradientSection>
       </form>
     </section>
   );

--- a/packages/compositions/src/button-gradient-section/button-gradient-section.css.ts
+++ b/packages/compositions/src/button-gradient-section/button-gradient-section.css.ts
@@ -9,7 +9,7 @@ export const ctaButtonArea = style({
   transform: 'translateX(-50%)',
   width: '100%',
   maxWidth: '43rem',
-  padding: '2rem',
+  padding: '2rem 2rem calc(2rem + env(safe-area-inset-bottom))',
   backgroundColor: ampThemeVars.color.gray_000,
   selectors: {
     '&::before': {

--- a/packages/compositions/src/notice-detail-layout/notice-detail-layout.css.ts
+++ b/packages/compositions/src/notice-detail-layout/notice-detail-layout.css.ts
@@ -35,7 +35,7 @@ export const contents = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
-  padding: '2rem 2rem 13.5rem',
+  padding: '2rem 2rem calc(13.5rem + env(safe-area-inset-bottom))',
 });
 
 export const category = style({
@@ -63,5 +63,5 @@ export const text = style({
 export const button = style({
   display: 'flex',
   gap: '1rem',
-  padding: '1.7rem 2rem',
+  padding: '1.7rem 2rem calc(1.7rem + env(safe-area-inset-bottom))',
 });

--- a/packages/compositions/src/notice-detail-layout/notice-detail-layout.css.ts
+++ b/packages/compositions/src/notice-detail-layout/notice-detail-layout.css.ts
@@ -35,7 +35,7 @@ export const contents = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
-  padding: '2rem',
+  padding: '2rem 2rem 13.5rem',
 });
 
 export const category = style({


### PR DESCRIPTION
## 📌 Summary

> #270 

## 📚 Tasks

- 공지 본문 영역 하단 패딩 추가

## 🔍 Describe
### 그라데이션 영역과 본문 겹침 이슈 해결
<img width="431" height="450" alt="스크린샷 2026-02-27 오후 1 24 04" src="https://github.com/user-attachments/assets/b3fe83e9-0112-422f-9a84-15b5c555fcbe" />

기존에는 하단 고정 버튼 영역 상단의 그라데이션 UI로 인해 본문 마지막 텍스트가 흐릿하게 보이는 문제가 있었어요.

하단 버튼 영역과 그라데이션 UI는 유지하고 본문 콘텐츠 영역에 하단 패딩을 추가해 마지막 텍스트가 해당 영역과 겹치지 않도록 개선했어요.

## 👀 To Reviewer
- 하단 CTA 버튼 영역에 그라데이션이 적용되지 않은 페이지들에 전반적으로 동일하게 적용했어요.
- 간단한 수정이지만 더 좋은 방법이 있다면 코멘트 부탁드립니당 !🤓

## 📸 Screenshot
<img width="431" height="566" alt="스크린샷 2026-02-27 오후 10 12 41" src="https://github.com/user-attachments/assets/86b4f758-aafc-4381-abb5-d6388545f63f" />
<img width="430" height="391" alt="스크린샷 2026-02-27 오후 10 42 55" src="https://github.com/user-attachments/assets/d774c079-edbc-4f43-996a-8b26b5d31803" />