### PR TITLE
Fix(audience): PWA 알림 두 번 가는 문제 수정

### DIFF
--- a/apps/audience/src/sw.ts
+++ b/apps/audience/src/sw.ts
@@ -52,8 +52,8 @@ type NotiData = {
 onBackgroundMessage(messaging, (payload) => {
   console.log('[SW] onBackgroundMessage:', payload);
 
-  const title = payload.notification?.title ?? '알림';
-  const body = payload.notification?.body ?? '';
+  const title = payload.data?.title ?? '알림';
+  const body = payload.data?.body ?? '';
 
   const festivalId = payload.data?.festivalId;
   const noticeId = payload.data?.noticeId;


### PR DESCRIPTION
## 📌 Summary

> #269 

PWA 알림 두 번 가는 문제 수정

## 📚 Tasks

-Service Worker에서 알림 제목/본문을 payload.data 기준으로 읽도록 변경

- 서버와 회의 후 notification payload 제거 후 data-only 메시지 전송으로 통일

## 🔍 Describe

### 배경
FCM 발송 payload에 data와 notification에 모두 title/body가 포함되어 있었습니다.

브라우저/FCM 환경에 따라 notification이 포함된 메시지는 자동으로 알림이 표시될 수 있는데,
동시에 SW에서 onBackgroundMessage로 showNotification()을 직접 호출하면서 알림이 2번 노출되는 문제가 발생했습니다.

또한 딥링크/식별자 전달을 위해 festivalId, noticeId 등은 data에 포함되어야 하므로, payload 구조를 data 중심으로 정리할 필요가 있었습니다.

### 개선 방향
SW에서 알림 렌더링 데이터를 payload.notification → payload.data로 변경했습니다.

title: payload.data?.title ?? '알림'

body: payload.data?.body ?? ''

festivalId/noticeId도 payload.data 기반으로 유지

서버 측 변경과 함께 최종적으로 data-only payload로 통일하여 중복 알림 가능성을 제거합니다.

