### PR TITLE
Chore(project): 이슈 및 PR 라벨링 자동화

### DIFF
--- a/.github/workflows/assign-auto-label.yml
+++ b/.github/workflows/assign-auto-label.yml
@@ -33,7 +33,7 @@ jobs:
             const labelsToAdd = [];
 
             const labelPatterns = {
-              '🐛 Fix': /\b(fix|Fix|FIX|bug|Bug|BUG|hotfix|Hotfix|HOTFIX|HotFix)\b/i,
+              '🐛 Fix': /\b(fix|Fix|FIX)\b/i,
               '✨ Feature': /\b(feat|Feat|FEAT)\b/i,
               '📝 Docs': /\b(docs|Docs|DOCS)\b/i,
               '⚙️ Init': /\b(init|Init|INIT)\b/i,

--- a/.github/workflows/assign-auto-label.yml
+++ b/.github/workflows/assign-auto-label.yml
@@ -1,0 +1,76 @@
+name: Auto Labeler
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, reopened]
+    branches: [develop]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Auto Labeling based on title
+        if: github.event_name == 'pull_request_target' || github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const payload = context.payload;
+            const isPR = !!payload.pull_request;
+            const target = isPR ? payload.pull_request : payload.issue;
+
+            const title = target.title;
+            const author = target.user.login;
+            const issueNumber = target.number;
+
+            const labelsToAdd = [];
+
+            const labelPatterns = {
+              '🐛 Fix': /\b(fix|Fix|FIX|bug|Bug|BUG|hotfix|Hotfix|HOTFIX|HotFix)\b/i,
+              '✨ Feature': /\b(feat|Feat|FEAT)\b/i,
+              '📝 Docs': /\b(docs|Docs|DOCS)\b/i,
+              '⚙️ Init': /\b(init|Init|INIT)\b/i,
+              '🎨 Design': /\b(design|Design|DESIGN)\b/i,
+              '🔧 Chore': /\b(chore|Chore|CHORE)\b/i,
+              '♻️ Refactor': /\b(refactor|Refactor|REFACTOR)\b/i,
+              '🔥 Hotfix': /\b(hotfix|Hotfix|HOTFIX)\b/i,
+              '🚀 Deploy': /\b(deploy|Deploy|DEPLOY)\b/i
+            };
+
+            for (const [label, pattern] of Object.entries(labelPatterns)) {
+              if (pattern.test(title)) {
+                labelsToAdd.push(label);
+              }
+            }
+
+            const userLabels = {
+              "Sohyunnnn": "🐰 소현", 
+              "jisooooooooooo": "🐵 지수",
+              "jin-evergreen": "🐻‍❄️ 진석",
+              "eunkr82": "🐱 나은"
+            };
+
+            if (userLabels[author]) {
+              labelsToAdd.push(userLabels[author]);
+            }
+
+            const uniqueLabels = [...new Set(labelsToAdd)];
+
+            if (uniqueLabels.length > 0) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: uniqueLabels
+                });
+              } catch (error) {
+              }
+            }


### PR DESCRIPTION
## 📌 Summary

- #288 

이슈 및 PR 작성 시 라벨링 자동화 파일을 추가했습니다.

## 📚 Tasks

- `.github/workflows` 경로에 라벨링 자동화 파일 추가

## 🔍 Describe

### 라벨링 자동화 파일 추가

기존에도 이슈 생성 시 템플릿 설정으로 인해 작업 종류 라벨은 자동으로 생성되었으나, 작성자 라벨은 매번 수동으로 설정해야 했어요. 추가로 PR 생성 시에는 작업 종류, 작성자 라벨을 모두 수동으로 설정해야 했어요.

Github Actions를 활용하여 이를 자동화하는 파일을 추가했어요. 이제 이슈/PR 제목의 키워드를 기반으로 작업 라벨을 자동으로 설정해요. 추가로 생성자의 깃허브 아이디를 인식하여 작성자 라벨 또한 자동으로 설정해요.

## 👀 To Reviewer

- 깃허브 아이디와 라벨명이 정확한지 확인 부탁드려요.
- 잘못 설정된 부분이 있다면 알려주세요!


<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
