### PR TITLE
Fix(audience): 칩 컴포넌트 스타일 일부 및 저장한 공지 뷰 콘텐츠 노출 수정

### DIFF
--- a/apps/audience/src/pages/saved-notices/saved-notices.tsx
+++ b/apps/audience/src/pages/saved-notices/saved-notices.tsx
@@ -38,7 +38,7 @@ const SavedNoticesPage = () => {
             <CardNotice
               imageUrl={notice.imageUrl}
               title={notice.title}
-              content={notice.categoryName}
+              content={notice.content}
               onClick={() => {
                 navigate(
                   generatePath(ROUTE_PATH.NOTICE_DETAILS, {

--- a/apps/audience/src/shared/types/saved-notices-response.ts
+++ b/apps/audience/src/shared/types/saved-notices-response.ts
@@ -3,6 +3,7 @@ export interface SavedNoticeItem {
   noticeId: number;
   festivalTitle: string;
   categoryName: string;
+  content: string;
   title: string;
   imageUrl: string;
 }

--- a/packages/ads-ui/src/components/chip/chip.css.ts
+++ b/packages/ads-ui/src/components/chip/chip.css.ts
@@ -72,7 +72,7 @@ export const chip = recipe({
     {
       variants: {
         variant: 'status',
-        status: 'completed',
+        status: 'upcoming',
       },
       style: {
         padding: '0.3rem 1.2rem',


### PR DESCRIPTION
## 📌 Summary

- #294 

이전 변경사항으로 인해 변경된 칩 컴포넌트 사이즈를 통일하고, 저장한 공지 뷰 콘텐츠 노출을 수정합니다.

## 📚 Tasks

- 칩 컴포넌트 스타일 파일 수정
- 저장한 공지 뷰 데이터 필드 매핑 수정

## 🔍 Describe

### 칩 컴포넌트 통일 및 저장한 공지 뷰 수정

이전 변경사항으로 인해 달라진 칩 컴포넌트 스타일을  `compoundVariants`를 수정하여 통일했어요.
추가로 기존에 `저장한 공지 뷰`에서 공지 제목과 카테고리 이름을 보여주고 있었는데, 기획 의도에 맞게 카테고리 이름 대신 공지 상세 내용을 보여주도록 수정했어요.

## 👀 To Reviewer

- 변경사항이 많지는 않지만, 추가로 수정할 사항은 없는지 확인해주세요!


## 📸 Screenshot

| Before (AS-IS) | After (TO-BE) |
| :-: | :-: |
| <img src="https://github.com/user-attachments/assets/e8396532-3abe-4ff8-bea5-ecb0e6a36eb7" width="400"> | <img src="https://github.com/user-attachments/assets/5f0149ce-679b-432c-8258-54138f21bc88" width="400"> |


