### PR TITLE
Chore(project): 이슈 및 PR 작성 시 Assignees 자동 할당

### DIFF
--- a/.github/workflows/assign-auto-label.yml
+++ b/.github/workflows/assign-auto-label.yml
@@ -74,3 +74,13 @@ jobs:
               } catch (error) {
               }
             }
+
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                assignees: [author] 
+              });
+            } catch (error) {
+            }


### PR DESCRIPTION
## 📌 Summary

- #297 

이슈 및 PR 작성 시 라벨 뿐 아니라 Assignees도 자동 할당되도록 했습니다.

## 📚 Tasks

- `assign-auto-label.yml` 파일 수정

## 🔍 Describe

### 이슈 및 PR 작성 시 Assignees 자동 할당
기존에는 라벨만 자동 할당되도록 설정했는데, Assignees도 함께 자동으로 할당되도록 관련 로직을 추가했습니다.


## 👀 To Reviewer

- 개선 사항이 있다면 알려주세요!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
