### PR TITLE
Fix(config): repository not found 오류 수정

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add fork remote
         run: |
-          git remote add forked-repo https://x-access-token:${{ secrets.FORKED_REPO_TOKEN }}@github.com/${{ secrets.FORKED_REPO_OWNER }}/${{ secrets.FORKED_REPO_NAME }}.git
+          git remote add forked-repo https://x-access-token:${{ secrets.FORKED_REPO_TOKEN }}@github.com/eunkr82/AMP-CLIENT.git
 
       - name: Push to fork (mirror main)
         run: |


### PR DESCRIPTION
## 📌 Summary

> #301 
repository not found 오류 수정

## 📚 Tasks

sync-fork.yml에서 owner / repo name 명시하도록 수정

## 🔍 Describe

Github Actions로 main 브랜치를 동기화하는 과정에서 repository not found 오류로 작업이 통과되지 못하는 오류가 있었어요. 
원인은 owner와 name을 Github Actions secrets로 관리하고 있었는데, 해당 값들이 런타임에서 빈 문자열로 평가되면서 잘못된 remote url이 발생해 push가 실패하는 것이었어요.
따라서 해당 값들을 secrets을 통해 전달하는 것이 아닌, 직접 명시하는 방식으로 파일을 수정했어요.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
