### PR TITLE
Fix(apps): 403 에러 핸들링 추가 및 알림 오류 수정

### DIFF
--- a/apps/audience/src/sw.ts
+++ b/apps/audience/src/sw.ts
@@ -53,7 +53,7 @@ onBackgroundMessage(messaging, (payload) => {
   console.log('[SW] onBackgroundMessage:', payload);
 
   const title = payload.data?.title ?? '알림';
-  const body = payload.data?.body ?? '';
+  const body = payload.data?.message ?? '';
 
   const festivalId = payload.data?.festivalId;
   const noticeId = payload.data?.noticeId;

--- a/packages/apis/src/http/instance.ts
+++ b/packages/apis/src/http/instance.ts
@@ -75,6 +75,11 @@ instance.interceptors.response.use(
       }
     }
 
+    if (status === HTTP_STATUS_CODE.FORBIDDEN) {
+      window.location.replace(`/login`);
+      return new Promise(() => {});
+    }
+
     if (status === HTTP_STATUS_CODE.NOT_FOUND) {
       const isOnNotFound = window.location.pathname.startsWith('/not-found');
 

--- a/packages/apis/src/http/instance.ts
+++ b/packages/apis/src/http/instance.ts
@@ -76,8 +76,12 @@ instance.interceptors.response.use(
     }
 
     if (status === HTTP_STATUS_CODE.FORBIDDEN) {
-      window.location.replace(`/login`);
-      return new Promise(() => {});
+      const isOnLogin = window.location.pathname.startsWith('/login');
+      if (!isOnLogin && !locked) {
+        setRedirectLock();
+        window.location.replace('/login');
+      }
+      return handleApiError(error);
     }
 
     if (status === HTTP_STATUS_CODE.NOT_FOUND) {


### PR DESCRIPTION
## 📌 Summary

> #300

403 에러 핸들링 추가 및 알림 오류 수정

## 📚 Tasks

- 403 에러 발생 시 로그인 페이지 리다이렉트 처리 추가

- 알림(Notification) 데이터 매핑 오류 수정

## 🔍 Describe

- host / audience 창을 동시에 띄운 경우 쿠키가 하나만 공유되면서, 다른 탭(사이트)에서 권한 불일치로 403이 발생하는 케이스가 있었습니다. 기존에는 이에 대한 공통 대응이 없어 빈 화면으로 남았고, 사용자가 복구할 수 있도록 403 발생 시 로그인 페이지로 이동하도록 에러 핸들링을 추가했습니다.

- 알림 영역에서 기존 notification 구조를 제거하고 data의 title, body를 사용하려 했으나, 서버 응답 필드가 message 등으로 스펙과 다르게 내려오는 이슈가 있어 실제 응답 필드에 맞게 매핑 로직을 수정했습니다.
<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

## 📸 Screenshot

<img width="690" height="170" alt="image" src="https://github.com/user-attachments/assets/78be5247-41b2-4089-b348-8649c001e8b6" />
