### PR TITLE
Refactor(ads): 텍스트필드 아이콘 작아지는 문제 수정

### DIFF
--- a/packages/ads-ui/src/components/textfield/textfield.css.ts
+++ b/packages/ads-ui/src/components/textfield/textfield.css.ts
@@ -7,7 +7,7 @@ import { ampThemeVars } from '../../styles';
 export const iconColorVar = createVar();
 
 const iconPadding = {
-  padding: '1.3rem 1.6rem',
+  padding: '1.2rem 1.5rem',
 } as const;
 
 export const textfield = recipe({
@@ -44,6 +44,7 @@ export const textfield = recipe({
 });
 
 export const icon = style({
+  flexShrink: 0,
   color: iconColorVar,
 });
 
@@ -53,6 +54,7 @@ export const input = style({
       color: ampThemeVars.color.gray_400,
     },
   },
+  padding: 0,
   color: ampThemeVars.color.gray_900,
   border: 'none',
   outline: 'none',


### PR DESCRIPTION
## 📌 Summary

> #314 

텍스트필드 아이콘 작아지는 문제 수정

## 📚 Tasks

- Textfield 아이콘 shrink 이슈 수정
- input 기본 padding 및 높이 보정


## 🔍 Describe

텍스트필드 아이콘이 피그마와 다르다는 QA가 있어 확인했습니다.

<img width="318" height="147" alt="스크린샷 2026-03-11 오전 12 44 21" src="https://github.com/user-attachments/assets/da268b70-c7a2-491a-8930-1885a762c446" />

### 원인

<img width="314" height="176" alt="스크린샷 2026-03-11 오전 12 11 55" src="https://github.com/user-attachments/assets/d1f7a52f-e3a9-4fe1-8e6a-ce3e53cb418b" />
<img width="374" height="231" alt="스크린샷 2026-03-11 오전 12 11 53" src="https://github.com/user-attachments/assets/db4d28fa-1afb-4d9a-a381-955c05b66eb0" />

- flex 레이아웃에서 아이콘이 shrink 되면서(폭이 부족할 때) 크기가 줄어드는 현상이 발생했습니다.
- 또한 input에 기본 padding이 적용되어 높이가 미세하게 달라지는 문제가 있었습니다.
- 피그마에서는 border를 포함한 사이즈 기준으로 패딩이 잡혀 있어, 현재 구현과 높이 기준이 달라 1px 보정이 필요했습니다.


### 해결
- icon에 `flex-shrink: 0`를 추가하여 아이콘이 줄어들지 않도록 수정했습니다.
- input 기본 padding 제거 및 높이 정렬을 위해 패딩을 조정했습니다. (border 포함 스펙에 맞춰 1px 보정)

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->


## 📸 Screenshot

<img width="419" height="198" alt="스크린샷 2026-03-11 오전 12 43 45" src="https://github.com/user-attachments/assets/47f6288b-0a9f-49a6-bd05-bfed89af5044" />

