### PR TITLE
Fix(apps): 디데이 데이터 필드명 통일로 인한 NaN 오류 해결

### DIFF
--- a/apps/audience/src/pages/home/home.tsx
+++ b/apps/audience/src/pages/home/home.tsx
@@ -33,7 +33,7 @@ const HomePage = () => {
           title={bannerFestival.title}
           location={bannerFestival.location}
           date={bannerFestival.period}
-          dday={bannerFestival.dDay}
+          dDay={bannerFestival.dDay}
         />
       ) : (
         <HomeBanner nickname={nickname} status='none' />

--- a/apps/audience/src/pages/home/model/use-home-festivals.ts
+++ b/apps/audience/src/pages/home/model/use-home-festivals.ts
@@ -36,7 +36,7 @@ const useHomeFestivals = () => {
           mainImageUrl: upcomingFestivalData.mainImageUrl,
           location: upcomingFestivalData.location,
           period: `${upcomingFestivalData.startDate} ~ ${upcomingFestivalData.endDate}`,
-          dDay: upcomingFestivalData.dday,
+          dDay: upcomingFestivalData.dDay,
         }
       : undefined,
     selectedTab,

--- a/apps/audience/src/pages/notice-list/notice-list.tsx
+++ b/apps/audience/src/pages/notice-list/notice-list.tsx
@@ -89,7 +89,7 @@ const NoticeListPage = () => {
 
   const bannerProps = bannerData
     ? {
-        dday: formatDday(bannerData.dday),
+        dDay: formatDday(bannerData.dDay),
         title: bannerData.title,
         location: bannerData.location,
         date: bannerData.period,
@@ -171,7 +171,7 @@ const NoticeListPage = () => {
     <main className={styles.pageContainer}>
       {bannerProps && (
         <NoticeBanner
-          dday={bannerProps.dday}
+          dDay={bannerProps.dDay}
           title={bannerProps.title}
           location={bannerProps.location}
           date={bannerProps.date}

--- a/apps/audience/src/shared/types/home-response.ts
+++ b/apps/audience/src/shared/types/home-response.ts
@@ -45,7 +45,7 @@ export interface UpcomingFestivalResponse {
   location: string;
   startDate: string;
   endDate: string;
-  dday: number;
+  dDay: number;
 }
 
 export interface NicknameResponse {

--- a/apps/audience/src/shared/types/notice-response.ts
+++ b/apps/audience/src/shared/types/notice-response.ts
@@ -40,7 +40,7 @@ export interface FestivalNoticeBanner {
   location: string;
   period: string;
   isWishlist: boolean;
-  dday: number;
+  dDay: number;
   activeCategories: ActiveCategory[];
 }
 

--- a/apps/audience/src/widgets/my-events/festival-list.tsx
+++ b/apps/audience/src/widgets/my-events/festival-list.tsx
@@ -13,7 +13,7 @@ const STATUS_CHIP: Record<MyEventsStatus, ReactElement> = {
     </Chip>
   ),
   '관람 예정': (
-    <Chip variant='status' status='dday'>
+    <Chip variant='status' status='dDay'>
       관람 예정
     </Chip>
   ),

--- a/apps/host/src/pages/notice-list/notice-list.tsx
+++ b/apps/host/src/pages/notice-list/notice-list.tsx
@@ -65,7 +65,7 @@ const NoticeListPage = () => {
     <main className={styles.pageContainer}>
       {festivalBanner && (
         <NoticeBanner
-          dday={formatDday(festivalBanner.dday)}
+          dDay={formatDday(festivalBanner.dDay)}
           title={festivalBanner.title}
           location={festivalBanner.location}
           date={festivalBanner.period}

--- a/apps/host/src/shared/types/festival.ts
+++ b/apps/host/src/shared/types/festival.ts
@@ -22,6 +22,6 @@ export interface FestivalNoticeBanner {
   location: string;
   period: string;
   isWishlist: boolean;
-  dday: number;
+  dDay: number;
   activeCategories: ActiveCategory[];
 }

--- a/packages/ads-ui/src/components/card/card-home/card-home.css.ts
+++ b/packages/ads-ui/src/components/card/card-home/card-home.css.ts
@@ -53,7 +53,7 @@ export const location = style({
   gap: '0.4rem',
 });
 
-export const dday = style({
+export const dDay = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.4rem',
@@ -61,7 +61,7 @@ export const dday = style({
   ...ampThemeVars.font.heading_b_22,
 });
 
-export const ddayText = style({
+export const dDayText = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/packages/ads-ui/src/components/card/card-home/card-home.tsx
+++ b/packages/ads-ui/src/components/card/card-home/card-home.tsx
@@ -6,10 +6,10 @@ interface CardHomeProps {
   title: string;
   location: string;
   date: string;
-  dday: number;
+  dDay: number;
 }
 
-const CardHome = ({ title, location, date, dday }: CardHomeProps) => {
+const CardHome = ({ title, location, date, dDay }: CardHomeProps) => {
   return (
     <article className={styles.background}>
       <div className={styles.contentContainer}>
@@ -29,7 +29,7 @@ const CardHome = ({ title, location, date, dday }: CardHomeProps) => {
             <p className={styles.ddayText}>D</p>
             <span>-</span>
             <p className={styles.ddayText}>
-              {dday === 0 ? 'Day' : Math.abs(dday)}
+              {dDay === 0 ? 'Day' : Math.abs(dDay)}
             </p>
           </div>
         </div>

--- a/packages/ads-ui/src/components/card/card-home/card-home.tsx
+++ b/packages/ads-ui/src/components/card/card-home/card-home.tsx
@@ -25,10 +25,10 @@ const CardHome = ({ title, location, date, dDay }: CardHomeProps) => {
             </div>
             <p>{date}</p>
           </div>
-          <div className={styles.dday}>
-            <p className={styles.ddayText}>D</p>
+          <div className={styles.dDay}>
+            <p className={styles.dDayText}>D</p>
             <span>-</span>
-            <p className={styles.ddayText}>
+            <p className={styles.dDayText}>
               {dDay === 0 ? 'Day' : Math.abs(dDay)}
             </p>
           </div>

--- a/packages/ads-ui/src/components/chip/chip.css.ts
+++ b/packages/ads-ui/src/components/chip/chip.css.ts
@@ -39,7 +39,7 @@ export const chip = recipe({
         backgroundColor: ampThemeVars.color.gray_100,
         color: ampThemeVars.color.gray_500,
       },
-      dday: {
+      dDay: {
         border: `1px solid ${ampThemeVars.color.gray_200}`,
         backgroundColor: ampThemeVars.color.gray_000,
         color: ampThemeVars.color.gray_500,
@@ -63,7 +63,7 @@ export const chip = recipe({
     {
       variants: {
         variant: 'status',
-        status: 'dday',
+        status: 'dDay',
       },
       style: {
         padding: '0.3rem 1.2rem',

--- a/packages/ads-ui/src/components/chip/chip.tsx
+++ b/packages/ads-ui/src/components/chip/chip.tsx
@@ -10,7 +10,7 @@ interface ChipBaseProps {
 
 interface ChipStatusProps extends ChipBaseProps {
   variant: 'status';
-  status: 'current' | 'upcoming' | 'dday' | 'completed';
+  status: 'current' | 'upcoming' | 'dDay' | 'completed';
 }
 
 interface ChipDayProps extends ChipBaseProps {

--- a/packages/compositions/src/banner/home-banner/home-banner.tsx
+++ b/packages/compositions/src/banner/home-banner/home-banner.tsx
@@ -7,7 +7,7 @@ interface HomeBannerCardProps extends HomeBannerBaseProps {
   title: string;
   location: string;
   date: string;
-  dday: number;
+  dDay: number;
 }
 
 interface HomeBannerNoneProps extends HomeBannerBaseProps {
@@ -45,13 +45,13 @@ const HomeBanner = (props: HomeBannerProps) => {
       : `${styles.banner} ${styles.bannerAudienceNone}`;
 
   if (status === 'card') {
-    const { title, location, date, dday } = props;
+    const { title, location, date, dDay } = props;
     return (
       <article className={bannerClassName}>
         <p className={styles.text}>
           {greeting} {message}
         </p>
-        <CardHome title={title} location={location} date={date} dday={dday} />
+        <CardHome title={title} location={location} date={date} dDay={dDay} />
       </article>
     );
   }

--- a/packages/compositions/src/banner/notice-banner/notice-banner.tsx
+++ b/packages/compositions/src/banner/notice-banner/notice-banner.tsx
@@ -8,7 +8,7 @@ interface NoticeBannerProps {
   title: string;
   location: string;
   date: string;
-  dday: string;
+  dDay: string;
   button?: ReactNode;
 }
 
@@ -16,14 +16,14 @@ const NoticeBanner = ({
   title,
   location,
   date,
-  dday,
+  dDay,
   button,
 }: NoticeBannerProps) => {
   return (
     <section className={styles.banner}>
       <div className={styles.content}>
         <Chip variant='day' status='color' className={styles.chip}>
-          {dday}
+          {dDay}
         </Chip>
 
         <div className={styles.text}>

--- a/packages/compositions/src/festival-status-group/festival-status-group.tsx
+++ b/packages/compositions/src/festival-status-group/festival-status-group.tsx
@@ -16,7 +16,7 @@ const FestivalStatusGroup = ({
   return (
     <>
       {dDay && (
-        <Chip variant='status' status='dday'>
+        <Chip variant='status' status='dDay'>
           {dDay}
         </Chip>
       )}


### PR DESCRIPTION
## 📌 Summary

- #318 

디데이 필드명 통일로 인한 NaN 오류를 해결했습니다.

## 📚 Tasks

- 기존 로직에  NaN 에러를 유발할 수 있는  `dday` 필드명 교체


## 🔍 Describe

### 디데이 필드명 통일
기존에는 API 별로 디데이 관련 데이터 필드명이 `dDay`, `dday`로 분산되어 있었습니다. 지난 번 서버와 논의하여 `dDay`로 통일하기로 하였고, 해당 작업이 마무리되어 기존 `dday`를 사용하여 NaN으로 표기되던 부분을, `dDay` 필드명으로 통일하여 정확한 날짜가 렌더링 될 수 있도록 하였습니다.


## 👀 To Reviewer

- 각 페이지에서 날짜가 잘 표시되는지, 오류가 발생하지는 않는지 확인해주세요!


## 📸 Screenshot

| Before | After |
| :-: | :-: |
| <img src="https://github.com/user-attachments/assets/a2787448-b1cd-4e02-b28d-eaedb842f051" width="400"> | <img src="https://github.com/user-attachments/assets/6ea8ca74-7519-4b86-b552-2072cefa9d65" width="400"> |

