### PR TITLE
Feat(host): 공지 수정 중 이탈 방지 모달 추가

### DIFF
--- a/packages/ads-ui/src/components/header/header.tsx
+++ b/packages/ads-ui/src/components/header/header.tsx
@@ -26,6 +26,7 @@ const CONFIRM_LEAVE_PATHS = [
   '/events/:eventId/notices/new',
   '/events/new',
   '/events/:eventId/edit',
+  '/events/:eventId/notices/:noticeId/edit',
 ] as const;
 
 const Header = ({


### PR DESCRIPTION
## 📌 Summary

- #326 

공지 수정 중 이탈 시 이탈 방지 모달을 렌더링 하도록 수정합니다.

## 📚 Tasks

- `CONFIRM_LEAVE_PATHS`에 공연 수정 경로 추가

## 🔍 Describe

### 공연 수정 중 이탈 방지 모달 추가

기존에는 공연 작성 시에만 이탈 방지 모달이 있었고, 공연 수정 시에는 없었습니다. 다만 기획 의도 상, 공연 작성/수정은 동일한 유즈케이스를 가져가기 때문에 공연 수정 시에도 이탈 방지 모달이 렌더링되도록 추가했습니다.


## 👀 To Reviewer

- 간단한 작업이라, 추가 리뷰 사항이 있다면 알려주세요!

## 📸 Screenshot

https://github.com/user-attachments/assets/228b0597-41ec-48f2-b16b-f508fb9586df


