### PR TITLE
Fix(apps): 뷰 스크롤 동작 관련 레이아웃 수정

### DIFF
--- a/apps/audience/src/widgets/home/components/home-festival-tabs/home-festival-tabs.css.ts
+++ b/apps/audience/src/widgets/home/components/home-festival-tabs/home-festival-tabs.css.ts
@@ -4,7 +4,7 @@ import { ampThemeVars } from '@amp/ads-ui/styles';
 
 export const tabsSticky = style({
   position: 'sticky',
-  top: 0,
+  top: 'var(--header-height)',
   zIndex: ampThemeVars.zIndex.sticky,
   backgroundColor: ampThemeVars.color.gray_000,
 });

--- a/apps/host/src/pages/home/home.css.ts
+++ b/apps/host/src/pages/home/home.css.ts
@@ -1,5 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
+import { ampThemeVars } from '@amp/ads-ui/styles';
+
 export const page = style({
   minHeight: '100dvh',
   paddingBottom: 'calc(11rem + env(safe-area-inset-bottom))',
@@ -19,4 +21,10 @@ export const ctaArea = style({
   flexDirection: 'column',
   alignItems: 'center',
   gap: '0.6rem',
+});
+
+export const bannerContainer = style({
+  position: 'sticky',
+  top: 'var(--header-height)',
+  zIndex: ampThemeVars.zIndex.sticky,
 });

--- a/apps/host/src/pages/home/home.tsx
+++ b/apps/host/src/pages/home/home.tsx
@@ -48,7 +48,9 @@ const HomePage = () => {
 
   return (
     <section className={styles.page}>
-      <CardHomebannerOrg nickname={nickname ?? 'SOPT'} />
+      <div className={styles.bannerContainer}>
+        <CardHomebannerOrg nickname={nickname ?? 'SOPT'} />
+      </div>
 
       <div className={styles.content}>
         <FestivalOverview


### PR DESCRIPTION
## 📌 Summary

- #340 

피그마 디자인과 실제 구현된 뷰 사이의 스크롤 동작 차이가 있어, 레이아웃을 일부 수정했습니다.

## 📚 Tasks

- 홈 레이아웃 일부 수정

## 🔍 Describe

### 뷰 스크롤 동작 관련 레이아웃 수정

주최사, 관객 서비스의 각 홈 뷰에서 스크롤 동작 관련 레이아웃이 기존 계획과 다르게 구현된 부분을 수정했습니다.

주최사의 경우, 홈에서 배너 위치를 고정하여 스크롤 시에도 이동하지 않도록 했습니다.
관객의 경우, 스크롤 시 탭바 고정 위치를 기존 최상단에서 헤더 아래로 수정했습니다.


## 👀 To Reviewer

- 수정사항이 제대로 작동하는지 확인 부탁드려요!


## 📸 Screenshot

### 📢 관객

#### Before

https://github.com/user-attachments/assets/55bef992-8a6f-4a9b-967f-1c4860c37ff3

#### After

https://github.com/user-attachments/assets/28ed7ada-9cf3-4621-be28-0bd7d3d53744



### 👥 주최사

#### Before
https://github.com/user-attachments/assets/ca3cff31-9e57-4c06-93c2-cca585c2806e

#### After
https://github.com/user-attachments/assets/3331542a-f9e1-4f36-bce9-54d112e7ae5a



