### PR TITLE
Feat(host): 공연 이미지 수정/삭제 기능 추가

### DIFF
--- a/apps/host/src/shared/hooks/use-object-url/use-object-url.ts
+++ b/apps/host/src/shared/hooks/use-object-url/use-object-url.ts
@@ -3,13 +3,30 @@ import { useEffect, useState } from 'react';
 interface UseObjectUrlReturn {
   url: string;
   setFile: (file: File) => void;
+  clear: () => void;
 }
 
 const useObjectUrl = (): UseObjectUrlReturn => {
   const [url, setUrl] = useState('');
 
+  const clear = () => {
+    setUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return '';
+    });
+  };
+
   const setFile = (file: File) => {
-    setUrl(URL.createObjectURL(file));
+    const nextUrl = URL.createObjectURL(file);
+
+    setUrl((prev) => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return nextUrl;
+    });
   };
 
   useEffect(() => {
@@ -20,7 +37,7 @@ const useObjectUrl = (): UseObjectUrlReturn => {
     };
   }, [url]);
 
-  return { url, setFile };
+  return { url, setFile, clear };
 };
 
 export default useObjectUrl;

--- a/apps/host/src/shared/ui/form/form-field/form-field.tsx
+++ b/apps/host/src/shared/ui/form/form-field/form-field.tsx
@@ -10,10 +10,17 @@ interface FormFieldProps {
 
 const FormField = ({ id, label, children }: FormFieldProps) => {
   return (
-    <label className={styles.field} htmlFor={id}>
-      {label && <p className={styles.fieldLabel}>{label}</p>}
+    <div className={styles.field}>
+      {label &&
+        (id ? (
+          <label htmlFor={id} className={styles.fieldLabel}>
+            {label}
+          </label>
+        ) : (
+          <p className={styles.fieldLabel}>{label}</p>
+        ))}
       {children}
-    </label>
+    </div>
   );
 };
 

--- a/apps/host/src/shared/ui/form/form-field/form-field.tsx
+++ b/apps/host/src/shared/ui/form/form-field/form-field.tsx
@@ -3,22 +3,14 @@ import type { ReactNode } from 'react';
 import * as styles from './form-field.css';
 
 interface FormFieldProps {
-  id?: string;
   label?: string;
   children: ReactNode;
 }
 
-const FormField = ({ id, label, children }: FormFieldProps) => {
+const FormField = ({ label, children }: FormFieldProps) => {
   return (
     <div className={styles.field}>
-      {label &&
-        (id ? (
-          <label htmlFor={id} className={styles.fieldLabel}>
-            {label}
-          </label>
-        ) : (
-          <p className={styles.fieldLabel}>{label}</p>
-        ))}
+      {label && <p className={styles.fieldLabel}>{label}</p>}
       {children}
     </div>
   );

--- a/apps/host/src/shared/ui/form/form-field/form-field.tsx
+++ b/apps/host/src/shared/ui/form/form-field/form-field.tsx
@@ -3,14 +3,22 @@ import type { ReactNode } from 'react';
 import * as styles from './form-field.css';
 
 interface FormFieldProps {
+  id?: string;
   label?: string;
   children: ReactNode;
 }
 
-const FormField = ({ label, children }: FormFieldProps) => {
+const FormField = ({ id, label, children }: FormFieldProps) => {
   return (
     <div className={styles.field}>
-      {label && <p className={styles.fieldLabel}>{label}</p>}
+      {label &&
+        (id ? (
+          <label htmlFor={id} className={styles.fieldLabel}>
+            {label}
+          </label>
+        ) : (
+          <span className={styles.fieldLabel}>{label}</span>
+        ))}
       {children}
     </div>
   );

--- a/apps/host/src/widgets/event-form/event-form.tsx
+++ b/apps/host/src/widgets/event-form/event-form.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react';
 
-import { AddImageButton, CtaButton, Textfield } from '@amp/ads-ui';
+import {
+  AddImageButton,
+  CtaButton,
+  ImagePreview,
+  Textfield,
+} from '@amp/ads-ui';
 import {
   CalendarIcon,
   FlagIcon,
@@ -72,6 +77,10 @@ const EventForm = ({
     eventLocation: initialValues?.eventLocation ?? '',
   });
 
+  const [existingImageUrl, setExistingImageUrl] = useState(
+    initialValues?.imageUrl ?? '',
+  );
+
   const image = useObjectUrl();
   const [mainImageFile, setMainImageFile] = useState<File | null>(null);
 
@@ -108,7 +117,7 @@ const EventForm = ({
 
   const canAddBooth = isFilled(form.boothTitle);
 
-  const previewImageUrl = image.url || initialValues?.imageUrl || '';
+  const previewImageUrl = image.url || existingImageUrl;
   const hasImage = Boolean(previewImageUrl);
   const hasCategory = activeCategoryIds.length > 0;
   const hasBooth = booths.items.length > 0;
@@ -120,6 +129,18 @@ const EventForm = ({
     hasBooth &&
     hasImage &&
     hasCategory;
+
+  const handleRemoveImage = () => {
+    setMainImageFile(null);
+    setExistingImageUrl('');
+    image.clear();
+  };
+
+  const handleImageChange = (file: File) => {
+    setMainImageFile(file);
+    setExistingImageUrl('');
+    image.setFile(file);
+  };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -148,13 +169,14 @@ const EventForm = ({
 
           <FormField label='공연 이미지'>
             <div className={styles.addImageContainer}>
-              <AddImageButton
-                imageUrl={previewImageUrl}
-                onFileChange={(file: File) => {
-                  setMainImageFile(file);
-                  image.setFile(file);
-                }}
-              />
+              {hasImage ? (
+                <ImagePreview
+                  src={previewImageUrl}
+                  onRemove={handleRemoveImage}
+                />
+              ) : (
+                <AddImageButton onFileChange={handleImageChange} />
+              )}
             </div>
           </FormField>
 

--- a/apps/host/src/widgets/event-form/event-form.tsx
+++ b/apps/host/src/widgets/event-form/event-form.tsx
@@ -180,7 +180,7 @@ const EventForm = ({
             </div>
           </FormField>
 
-          <FormField label='공연명'>
+          <FormField id='eventTitle' label='공연명'>
             <Textfield
               name='eventTitle'
               variant='default'
@@ -192,7 +192,7 @@ const EventForm = ({
             />
           </FormField>
 
-          <FormField label='공연 일시'>
+          <FormField id='scheduleDate' label='공연 일시'>
             <div className={styles.grid}>
               <Textfield
                 id='scheduleDate'
@@ -241,7 +241,7 @@ const EventForm = ({
             />
           </FormField>
 
-          <FormField label='공연 장소'>
+          <FormField id='eventLocation' label='공연 장소'>
             <Textfield
               id='eventLocation'
               name='eventLocation'
@@ -265,7 +265,7 @@ const EventForm = ({
             관객이 현장 혼잡도를 직접 입력할 수 있어요.
           </p>
 
-          <FormField>
+          <FormField id='boothTitle'>
             <Textfield
               id='boothTitle'
               name='boothTitle'

--- a/apps/host/src/widgets/event-form/event-form.tsx
+++ b/apps/host/src/widgets/event-form/event-form.tsx
@@ -180,7 +180,7 @@ const EventForm = ({
             </div>
           </FormField>
 
-          <FormField id='eventTitle' label='공연명'>
+          <FormField label='공연명'>
             <Textfield
               name='eventTitle'
               variant='default'
@@ -192,7 +192,7 @@ const EventForm = ({
             />
           </FormField>
 
-          <FormField id='scheduleDate' label='공연 일시'>
+          <FormField label='공연 일시'>
             <div className={styles.grid}>
               <Textfield
                 id='scheduleDate'
@@ -241,7 +241,7 @@ const EventForm = ({
             />
           </FormField>
 
-          <FormField id='eventLocation' label='공연 장소'>
+          <FormField label='공연 장소'>
             <Textfield
               id='eventLocation'
               name='eventLocation'
@@ -265,7 +265,7 @@ const EventForm = ({
             관객이 현장 혼잡도를 직접 입력할 수 있어요.
           </p>
 
-          <FormField id='boothTitle'>
+          <FormField>
             <Textfield
               id='boothTitle'
               name='boothTitle'


### PR DESCRIPTION
## 📌 Summary

> #338
공연 이미지 수정/삭제 기능 추

## 📚 Tasks

- event-form에서 이미지가 있을 때 ImagePreview 컴포넌트를 렌더링 처리
- useObjectUrl 훅에 clear 함수 추가

## 🔍 Describe

공연 이미지의 수정/삭제가 가능하도록, 이미지가 있을 때는 ImagePreview 컴포넌트를, 없을 때는 AddImageButton 컴포넌트를 렌더링하도록 처리했어요.

기존에는 `initialValues?.imageUrl` 과 object url 기반 미리보기를 우선순위로 합쳐서 사용하고 있었기 때문에, 삭제 버튼을 눌렀을 때 어떤 값을 제거해야 하는지 모호한 상태였어요.
이를 개선하기 위해 이번 PR에서는 이미지와 관련된 상태를 역할별로 분리해서, 기존 이미지 파일 / 새로 선택한 파일 / 미리보기 URL이 서로 다른 책임을 가지도록 구조를 정리했습니다.

또한 이미지 삭제 시에는 파일 상태뿐만 아니라 미리보기로 생성된 object URL도 함께 정리할 수 있도록 clear 함수를 추가했어요.




## 👀 To Reviewer
event-form을 포함한 공연 페이지 관련 리펙토링은 수정 범위가 넓을 것 같아 따로 이슈를 파서 진행할 예정이에요.
정상작동하는지, 개선사항 있는지 확인 부탁드려요!



## 📸 Screenshot
<img width="487" height="201" alt="image" src="https://github.com/user-attachments/assets/e3eb8764-c285-4cfb-b399-9b6ed970e863" />
<img width="572" height="192" alt="image" src="https://github.com/user-attachments/assets/c1906018-5cf1-4260-914f-e0505dc17fec" />


