### PR TITLE
Fix(audience): 모바일 환경에서의 관람 예정 해제 오류 해결

### DIFF
--- a/apps/audience/src/widgets/home/components/festival-card/festival-card.tsx
+++ b/apps/audience/src/widgets/home/components/festival-card/festival-card.tsx
@@ -85,10 +85,10 @@ const FestivalCard = ({
       {showWishList && (
         <CardFestival.Button>
           <FlagButton
+            key={festivalId}
             selected={wishList}
             onChange={toggleWishList}
             disabled={isTogglePending}
-            festivalId={festivalId}
           />
         </CardFestival.Button>
       )}

--- a/apps/audience/src/widgets/home/components/festival-card/festival-card.tsx
+++ b/apps/audience/src/widgets/home/components/festival-card/festival-card.tsx
@@ -88,6 +88,7 @@ const FestivalCard = ({
             selected={wishList}
             onChange={toggleWishList}
             disabled={isTogglePending}
+            festivalId={festivalId}
           />
         </CardFestival.Button>
       )}

--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -6,9 +6,15 @@ interface FlagButtonProps {
   selected: boolean;
   onChange: () => void;
   disabled?: boolean;
+  festivalId: number;
 }
 
-const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
+const FlagButton = ({
+  selected,
+  onChange,
+  disabled,
+  festivalId,
+}: FlagButtonProps) => {
   return (
     <button
       type='button'
@@ -22,9 +28,15 @@ const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
       disabled={disabled}
     >
       {selected ? (
-        <AmpFlagGradientIcon className={styles.icon} />
+        <AmpFlagGradientIcon
+          key={`gradient-flag-${festivalId}`}
+          className={styles.icon}
+        />
       ) : (
-        <AmpFlagIcon className={styles.icon} />
+        <AmpFlagIcon
+          key={`normal-flag-${festivalId}`}
+          className={styles.icon}
+        />
       )}
     </button>
   );

--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -6,15 +6,9 @@ interface FlagButtonProps {
   selected: boolean;
   onChange: () => void;
   disabled?: boolean;
-  festivalId: number;
 }
 
-const FlagButton = ({
-  selected,
-  onChange,
-  disabled,
-  festivalId,
-}: FlagButtonProps) => {
+const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
   return (
     <button
       type='button'
@@ -28,15 +22,9 @@ const FlagButton = ({
       disabled={disabled}
     >
       {selected ? (
-        <AmpFlagGradientIcon
-          key={`gradient-flag-${festivalId}`}
-          className={styles.icon}
-        />
+        <AmpFlagGradientIcon className={styles.icon} />
       ) : (
-        <AmpFlagIcon
-          key={`normal-flag-${festivalId}`}
-          className={styles.icon}
-        />
+        <AmpFlagIcon className={styles.icon} />
       )}
     </button>
   );


### PR DESCRIPTION
## 📌 Summary

- #345 

모바일 웹 또는 모바일 PWA 환경에서 관람 예정 해제 시 하단 깃발 svg가 사라지는 오류를 해결합니다.

## 📚 Tasks

- `FlagButton` 컴포넌트에 `key` 할당

## 🔍 Describe

### 모바일 환경에서의 관람 예정 해제 오류 해결

#### 이번 PR은 오류 원인에 잘못된 방향으로 접근하여, 후속 PR에서 다시 처리했습니다. 아래 PR로 이동해서 확인 부탁드립니다!
- #350 

<hr>

`관람 예정` 탭에서 공연 카드 해제 시, 리스트가 갱신되면서 아래에 있던 카드의 깃발 아이콘이 사라지는 현상이 발생했습니다. 데스크탑 환경에서는 정상 동작하지만, 특히 모바일 웹이나 모바일 PWA 환경에서 발생했습니다.

아마 `FestivalCard` 내부의 `FlagButton`에 고유 `key`가 없어서 발생하는 렌더링 동기화 문제로 판단했습니다. 리스트의 첫 번째 요소 삭제 시, 리액트는 동일한 구조의 하위 컴포넌트를 재사용하려 합니다. 이때 `FlagButton`은 컴포넌트 내 유일한 요소이므로 항상 동일한 0번 인덱스를 유지하기 때문에, 브라우저는 이를 변경사항 없음으로 판단하여 svg 리페인트 과정을 생략하는 것 같습니다. 아마 데스크탑에 비해 리페인트에 더 엄격한 모바일 webkit에서 주로 문제가 발생한다고 판단하고 있습니다.

이를 해결하기 위해 `FlagButton`에 카드의 고유한 값인 `festivalId`를 활용하여 `key`를 할당했습니다. 이를 통해 기존 노드가 아닌 새로운 노드를 생성하여, 모바일 환경에서도 누락 없이 아이콘을 다시 그리도록 했습니다.





## 👀 To Reviewer

이는 저의 개인적인 의견이고, 배포 후 모바일 PWA 환경에서 테스트가 필요합니다. 이 수정으로 이슈가 해결되지 않을 수도 있고, 근본적으로 최선의 해결 방법이 아닐 수도 있기 때문에 더 나은 방법이나 다른 방법에 대해 의견 주시면 감사하겠습니다!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
