### PR TITLE
Fix(audience): 모바일 환경에서의 svg 사라짐 오류 해결

### DIFF
--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -1,4 +1,5 @@
-import { AmpFlagGradientIcon, AmpFlagIcon } from '@amp/ads-ui/icons';
+import { AMP_FLAG_GRADIENT_ICON_URL } from '@amp/ads-ui/icon-urls';
+import { AmpFlagIcon } from '@amp/ads-ui/icons';
 
 import * as styles from './flag-button.css';
 
@@ -23,7 +24,7 @@ const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
     >
       {selected ? (
         <img
-          src={AmpFlagGradientIcon}
+          src={AMP_FLAG_GRADIENT_ICON_URL}
           className={styles.icon}
           alt='Gradient Flag'
         />

--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -23,11 +23,7 @@ const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
       disabled={disabled}
     >
       {selected ? (
-        <img
-          src={AMP_FLAG_GRADIENT_ICON_URL}
-          className={styles.icon}
-          alt='Gradient Flag'
-        />
+        <img src={AMP_FLAG_GRADIENT_ICON_URL} className={styles.icon} alt='' />
       ) : (
         <AmpFlagIcon className={styles.icon} />
       )}

--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -22,7 +22,11 @@ const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
       disabled={disabled}
     >
       {selected ? (
-        <img src={AmpFlagGradientIcon} alt='Gradient Flag' />
+        <img
+          src={AmpFlagGradientIcon}
+          className={styles.icon}
+          alt='Gradient Flag'
+        />
       ) : (
         <AmpFlagIcon className={styles.icon} />
       )}

--- a/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
+++ b/apps/audience/src/widgets/home/components/flag-button/flag-button.tsx
@@ -22,7 +22,7 @@ const FlagButton = ({ selected, onChange, disabled }: FlagButtonProps) => {
       disabled={disabled}
     >
       {selected ? (
-        <AmpFlagGradientIcon className={styles.icon} />
+        <img src={AmpFlagGradientIcon} alt='Gradient Flag' />
       ) : (
         <AmpFlagIcon className={styles.icon} />
       )}

--- a/packages/ads-ui/package.json
+++ b/packages/ads-ui/package.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./src/components/index.ts",
     "./icons": "./src/icons/index.ts",
+    "./icon-urls": "./src/icons/icon-urls.ts",
     "./styles": "./src/styles/index.ts",
     "./assets": "./src/assets/index.ts",
     "./styles/theme.css": "./src/styles/theme.css.ts",

--- a/packages/ads-ui/src/icons/icon-urls.ts
+++ b/packages/ads-ui/src/icons/icon-urls.ts
@@ -1,0 +1,1 @@
+export { default as AMP_FLAG_GRADIENT_ICON_URL } from './svgs/icn_ampflag_gradient.svg?url';

--- a/packages/ads-ui/src/icons/index.ts
+++ b/packages/ads-ui/src/icons/index.ts
@@ -1,6 +1,6 @@
 export { default as AlertIcon } from './svgs/icn_alert.svg?react';
 export { default as AmpFlagIcon } from './svgs/icn_ampflag.svg?react';
-export { default as AmpFlagGradientIcon } from './svgs/icn_ampflag_gradient.svg?react';
+export { default as AmpFlagGradientIcon } from './svgs/icn_ampflag_gradient.svg';
 export { default as ArrowIcon } from './svgs/icn_arrow.svg?react';
 export { default as BackIcon } from './svgs/icn_back.svg?react';
 export { default as CalendarIcon } from './svgs/icn_calendar.svg?react';

--- a/packages/ads-ui/src/icons/index.ts
+++ b/packages/ads-ui/src/icons/index.ts
@@ -1,6 +1,5 @@
 export { default as AlertIcon } from './svgs/icn_alert.svg?react';
 export { default as AmpFlagIcon } from './svgs/icn_ampflag.svg?react';
-export { default as AmpFlagGradientIcon } from './svgs/icn_ampflag_gradient.svg?url';
 export { default as ArrowIcon } from './svgs/icn_arrow.svg?react';
 export { default as BackIcon } from './svgs/icn_back.svg?react';
 export { default as CalendarIcon } from './svgs/icn_calendar.svg?react';

--- a/packages/ads-ui/src/icons/index.ts
+++ b/packages/ads-ui/src/icons/index.ts
@@ -1,6 +1,6 @@
 export { default as AlertIcon } from './svgs/icn_alert.svg?react';
 export { default as AmpFlagIcon } from './svgs/icn_ampflag.svg?react';
-export { default as AmpFlagGradientIcon } from './svgs/icn_ampflag_gradient.svg';
+export { default as AmpFlagGradientIcon } from './svgs/icn_ampflag_gradient.svg?url';
 export { default as ArrowIcon } from './svgs/icn_arrow.svg?react';
 export { default as BackIcon } from './svgs/icn_back.svg?react';
 export { default as CalendarIcon } from './svgs/icn_calendar.svg?react';

--- a/packages/ads-ui/src/types/svg.d.ts
+++ b/packages/ads-ui/src/types/svg.d.ts
@@ -11,7 +11,7 @@ declare module '*.webp' {
   export default src;
 }
 
-declare module '*.svg' {
-  const content: string;
-  export default content;
+declare module '*?url' {
+  const src: string;
+  export default src;
 }

--- a/packages/ads-ui/src/types/svg.d.ts
+++ b/packages/ads-ui/src/types/svg.d.ts
@@ -10,3 +10,8 @@ declare module '*.webp' {
   const src: string;
   export default src;
 }
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/packages/ads-ui/src/types/svg.d.ts
+++ b/packages/ads-ui/src/types/svg.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module '*.svg?react' {
   import * as React from 'react';
   const ReactComponent: React.FC<

--- a/packages/ads-ui/src/types/svg.d.ts
+++ b/packages/ads-ui/src/types/svg.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="vite/client" />
-
 declare module '*.svg?react' {
   import * as React from 'react';
   const ReactComponent: React.FC<

--- a/packages/ads-ui/tsconfig.json
+++ b/packages/ads-ui/tsconfig.json
@@ -4,8 +4,7 @@
     "noEmit": true,
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist",
-    "types": ["vite/client"]
+    "outDir": "dist"
   },
   "include": ["src", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/ads-ui/tsconfig.json
+++ b/packages/ads-ui/tsconfig.json
@@ -4,7 +4,8 @@
     "noEmit": true,
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["vite/client"]
   },
   "include": ["src", "src/**/*.d.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/compositions/src/vite-env.d.ts
+++ b/packages/compositions/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## 📌 Summary

- #349 

모바일 환경에서 관람 예정 버튼 해제 시, 아이콘이 사라지는 문제를 해결합니다.

## 📚 Tasks

- 그라디언트 아이콘 렌더링 방식을 `svgr`에서 `img` 태그 활용으로 변경

## 🔍 Describe

### 모바일 환경에서의 svg 사라짐 오류 해결

지난 PR에서 오류가 해결되지 않아, 다시 처음부터 원인을 생각했습니다.

일반 단색 svg와 달리 그라디언트가 적용된 svg에서만 오류가 발생하는 것으로 보아, 해당 파일에 원인이 있겠다고 생각했습니다. 확인 결과, 그라디언트가 적용된 svg 파일은 파일 내부에서 그라디언트 정의를 위해 고정된 `id`를 참조하고 있었습니다. 
```svg
<linearGradient id="paint0_linear_524_15277" x1="9.64982" y1="4.34995" x2="24.4999" y2="15" >
...
</linearGradient>
```

현재 저희는 모든 svg를 `svgr`을 통해 인라인 컴포넌트로 사용하고 있습니다. 이 경우, 동일한 아이콘이 한 페이지 내에 여러 번 렌더링되면 동일한 id가 중복 생성되고 고유하지 않은 id는 충돌 가능성이 있겠다고 판단했습니다. 특정 요소가 언마운트 되어 사라지면, 동일한 id를 참조하던 아이콘도 참조 대상을 잃어버려 그라디언트가 적용되지 않거나 아이콘 자체가 투명하게 보이는 현상이 발생했을 것이라 추측해볼 수 있습니다.


따라서 해당 아이콘을 `svgr` 형태로 사용하지 않고 `img` 태그의 `src`로 호출하도록 했습니다. 이렇게 할 경우, 브라우저는 `img`로 불러온 리소스를 독립된 문서로 취급하므로 내부 id가 외부 DOM이나 다른 아이콘과 충돌하지 않습니다.

`gradientFlag` 컴포넌트를 따로 정의하여 `useId`를 통해 아이디 중복을 막는 방법 등 많은 방법을 고민했지만, 오히려 더 복잡해지는 것 같았습니다. **색상 변경이 필요없는 정적 그라디언트 아이콘**이기에, 이미지 태그를 통해 격리하는 것이 지금 상황에서는 가장 적은 변경으로 오류를 해결할 수 있는 방법이라 판단했습니다.




## 👀 To Reviewer

- 처음 접한 오류라 시행착오가 많았는데, 더 나은 방법이 있다면 알려주세요!
- 정상적으로 작동하는지 확인 부탁드립니다!

`ngrok`을 활용하여 로컬 환경에서 모바일 테스트는 해봤는데, 배포 후 한번 더 확인이 필요합니다👀



## 📸 Screenshot

#### Before

https://github.com/user-attachments/assets/cbd13eba-c7eb-41c7-9933-249f2a02cf7c


#### After

https://github.com/user-attachments/assets/d4847e25-63cf-40c6-889a-093e195e03c4




