### PR TITLE
Refactor(host): 공지사항 다중 이미지 업로드 속도 최적화

### DIFF
--- a/apps/host/package.json
+++ b/apps/host/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.90.16",
     "@vanilla-extract/css": "catalog:",
     "@vanilla-extract/recipes": "catalog:",
+    "browser-image-compression": "^2.0.2",
     "firebase": "^12.8.0",
     "overlay-kit": "^1.8.6",
     "react": "catalog:",

--- a/apps/host/src/features/notice/use-image-upload.ts
+++ b/apps/host/src/features/notice/use-image-upload.ts
@@ -25,6 +25,7 @@ export const useImageUpload = (initialUrls: string[] = []) => {
   );
 
   const [isCompressing, setIsCompressing] = useState(false);
+  const compressingTaskCountRef = useRef(0);
   const blobUrlsRef = useRef<Set<string>>(new Set());
 
   const handleImagesAdd = async (files: File[]) => {
@@ -70,6 +71,7 @@ export const useImageUpload = (initialUrls: string[] = []) => {
     });
 
     setImages((prev) => [...prev, ...newItems]);
+    compressingTaskCountRef.current += 1;
     setIsCompressing(true);
 
     try {
@@ -95,7 +97,11 @@ export const useImageUpload = (initialUrls: string[] = []) => {
     } catch {
       toast.show('이미지 업로드 중 오류가 발생했습니다.');
     } finally {
-      setIsCompressing(false);
+      compressingTaskCountRef.current = Math.max(
+        0,
+        compressingTaskCountRef.current - 1,
+      );
+      setIsCompressing(compressingTaskCountRef.current > 0);
     }
   };
 

--- a/apps/host/src/features/notice/use-image-upload.ts
+++ b/apps/host/src/features/notice/use-image-upload.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from 'react';
 
 import { toast } from '@amp/ads-ui';
 
+import { compressImageFiles } from '@shared/libs/image-compress';
+
 const MAX_COUNT = 20;
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
@@ -22,9 +24,10 @@ export const useImageUpload = (initialUrls: string[] = []) => {
     initialUrls.map((url) => ({ type: 'existing', url })),
   );
 
+  const [isCompressing, setIsCompressing] = useState(false);
   const blobUrlsRef = useRef<Set<string>>(new Set());
 
-  const handleImagesAdd = (files: File[]) => {
+  const handleImagesAdd = async (files: File[]) => {
     const currentCount = images.length;
     const availableSpace = MAX_COUNT - currentCount;
     let hasLargeFile = false;
@@ -55,7 +58,7 @@ export const useImageUpload = (initialUrls: string[] = []) => {
       return;
     }
 
-    const newItems: NoticeImageItem[] = filesToAdd.map((file) => {
+    const newItems: NewImage[] = filesToAdd.map((file) => {
       const previewUrl = URL.createObjectURL(file);
       blobUrlsRef.current.add(previewUrl);
       return {
@@ -67,6 +70,33 @@ export const useImageUpload = (initialUrls: string[] = []) => {
     });
 
     setImages((prev) => [...prev, ...newItems]);
+    setIsCompressing(true);
+
+    try {
+      const targets = newItems.map((item) => ({
+        id: item.id,
+        file: item.file,
+      }));
+      const compressedResults = await compressImageFiles(targets);
+
+      setImages((prev) =>
+        prev.map((image) => {
+          if (image.type === 'new') {
+            const result = compressedResults.find(
+              (result) => result.id === image.id,
+            );
+            if (result) {
+              return { ...image, file: result.file };
+            }
+          }
+          return image;
+        }),
+      );
+    } catch {
+      toast.show('이미지 업로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsCompressing(false);
+    }
   };
 
   const handleImageRemove = (indexToRemove: number) => {
@@ -91,5 +121,5 @@ export const useImageUpload = (initialUrls: string[] = []) => {
     };
   }, []);
 
-  return { images, handleImagesAdd, handleImageRemove };
+  return { images, handleImagesAdd, handleImageRemove, isCompressing };
 };

--- a/apps/host/src/features/notice/use-image-upload.ts
+++ b/apps/host/src/features/notice/use-image-upload.ts
@@ -94,8 +94,6 @@ export const useImageUpload = (initialUrls: string[] = []) => {
           return image;
         }),
       );
-    } catch {
-      toast.show('이미지 업로드 중 오류가 발생했습니다.');
     } finally {
       compressingTaskCountRef.current = Math.max(
         0,

--- a/apps/host/src/features/notice/use-image-upload.ts
+++ b/apps/host/src/features/notice/use-image-upload.ts
@@ -84,11 +84,11 @@ export const useImageUpload = (initialUrls: string[] = []) => {
       setImages((prev) =>
         prev.map((image) => {
           if (image.type === 'new') {
-            const result = compressedResults.find(
-              (result) => result.id === image.id,
+            const compressedItem = compressedResults.find(
+              (item) => item.id === image.id,
             );
-            if (result) {
-              return { ...image, file: result.file };
+            if (compressedItem) {
+              return { ...image, file: compressedItem.file };
             }
           }
           return image;

--- a/apps/host/src/features/notice/use-notice-form.ts
+++ b/apps/host/src/features/notice/use-notice-form.ts
@@ -151,6 +151,6 @@ export const useNoticeForm = (
     },
     isValid,
     isSubmitting: isCreatePending || isUpdatePending,
-    isCompressing: isCompressing,
+    isCompressing,
   };
 };

--- a/apps/host/src/features/notice/use-notice-form.ts
+++ b/apps/host/src/features/notice/use-notice-form.ts
@@ -150,6 +150,7 @@ export const useNoticeForm = (
       handleSubmit,
     },
     isValid,
-    isSubmitting: isCreatePending || isUpdatePending || isCompressing,
+    isSubmitting: isCreatePending || isUpdatePending,
+    isCompressing: isCompressing,
   };
 };

--- a/apps/host/src/features/notice/use-notice-form.ts
+++ b/apps/host/src/features/notice/use-notice-form.ts
@@ -22,9 +22,8 @@ export const useNoticeForm = (
 ) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { images, handleImagesAdd, handleImageRemove } = useImageUpload(
-    initialData?.imageUrls,
-  );
+  const { images, handleImagesAdd, handleImageRemove, isCompressing } =
+    useImageUpload(initialData?.imageUrls);
 
   const [form, setForm] = useState({
     title: initialData?.title ?? '',
@@ -108,6 +107,7 @@ export const useNoticeForm = (
     if (
       isCreatePending ||
       isUpdatePending ||
+      isCompressing ||
       !isValid ||
       !festivalId ||
       form.categoryId === null
@@ -150,6 +150,6 @@ export const useNoticeForm = (
       handleSubmit,
     },
     isValid,
-    isSubmitting: isCreatePending || isUpdatePending,
+    isSubmitting: isCreatePending || isUpdatePending || isCompressing,
   };
 };

--- a/apps/host/src/pages/notice-create/notice-form.tsx
+++ b/apps/host/src/pages/notice-create/notice-form.tsx
@@ -8,7 +8,7 @@ import {
   Textfield,
 } from '@amp/ads-ui';
 import { PinIcon } from '@amp/ads-ui/icons';
-import { ButtonGradientSection } from '@amp/compositions';
+import { ButtonGradientSection, Loading } from '@amp/compositions';
 
 import MultiImageAddButton from '@widgets/multi-image-add-button/multi-image-add-button';
 
@@ -38,12 +38,13 @@ const NoticeForm = ({
   pinnedCount,
 }: NoticeFormProps) => {
   const { scrollRef, onDragStart, onDragEnd, onDragMove } = useDragScroll();
-  const { formState, handlers, isValid, isSubmitting } = useNoticeForm(
-    festivalId,
-    noticeDetail,
-    noticeDetail?.noticeId,
-    pinnedCount,
-  );
+  const { formState, handlers, isValid, isSubmitting, isCompressing } =
+    useNoticeForm(
+      festivalId,
+      noticeDetail,
+      noticeDetail?.noticeId,
+      pinnedCount,
+    );
 
   const categories = useMemo(
     () =>
@@ -63,6 +64,10 @@ const NoticeForm = ({
     handleFormChange,
     handleSubmit,
   } = handlers;
+
+  if (isSubmitting) {
+    return <Loading />;
+  }
 
   return (
     <>
@@ -151,7 +156,7 @@ const NoticeForm = ({
             type='common'
             htmlType='submit'
             color='gray'
-            disabled={!isValid || isSubmitting}
+            disabled={!isValid || isSubmitting || isCompressing}
           >
             완료
           </CtaButton>

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -1,4 +1,4 @@
-import imageCompression from 'browser-image-compression';
+import imageCompression, { type Options } from 'browser-image-compression';
 
 export interface CompressTargetImage {
   id: string;
@@ -8,7 +8,7 @@ export interface CompressTargetImage {
 export const compressImageFiles = async (
   items: CompressTargetImage[],
 ): Promise<CompressTargetImage[]> => {
-  const options = {
+  const options: Options = {
     maxSizeMB: 1,
     maxWidthOrHeight: 1920,
     useWebWorker: true,

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -1,0 +1,30 @@
+import imageCompression from 'browser-image-compression';
+
+export interface CompressTargetImage {
+  id: string;
+  file: File;
+}
+
+export const compressImageFiles = async (
+  items: CompressTargetImage[],
+): Promise<CompressTargetImage[]> => {
+  const options = {
+    maxSizeMB: 1,
+    maxWidthOrHeight: 1920,
+    useWebWorker: true,
+  };
+
+  return Promise.all(
+    items.map(async (item) => {
+      try {
+        const compressedBlob = await imageCompression(item.file, options);
+        const compressedFile = new File([compressedBlob], item.file.name, {
+          type: compressedBlob.type,
+        });
+        return { id: item.id, file: compressedFile };
+      } catch {
+        return { id: item.id, file: item.file };
+      }
+    }),
+  );
+};

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -19,6 +19,11 @@ export const compressImageFiles = async (
     items.map(async (item) => {
       try {
         const compressedBlob = await imageCompression(item.file, options);
+
+        if (compressedBlob.size >= item.file.size) {
+          return { id: item.id, file: item.file };
+        }
+
         const newFileName = item.file.name.replace(/\.[^/.]+$/, '.webp');
         const compressedFile = new File([compressedBlob], newFileName, {
           type: compressedBlob.type,

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -19,7 +19,8 @@ export const compressImageFiles = async (
     items.map(async (item) => {
       try {
         const compressedBlob = await imageCompression(item.file, options);
-        const compressedFile = new File([compressedBlob], item.file.name, {
+        const newFileName = item.file.name.replace(/\.[^/.]+$/, '.webp');
+        const compressedFile = new File([compressedBlob], newFileName, {
           type: compressedBlob.type,
         });
         return { id: item.id, file: compressedFile };

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -12,6 +12,7 @@ export const compressImageFiles = async (
     maxSizeMB: 1,
     maxWidthOrHeight: 1920,
     useWebWorker: true,
+    fileType: 'image/webp',
   };
 
   return Promise.all(

--- a/apps/host/src/shared/libs/image-compress.ts
+++ b/apps/host/src/shared/libs/image-compress.ts
@@ -24,7 +24,10 @@ export const compressImageFiles = async (
           return { id: item.id, file: item.file };
         }
 
-        const newFileName = item.file.name.replace(/\.[^/.]+$/, '.webp');
+        const newFileName = item.file.name.includes('.')
+          ? item.file.name.replace(/\.[^/.]+$/, '.webp')
+          : `${item.file.name}.webp`;
+
         const compressedFile = new File([compressedBlob], newFileName, {
           type: compressedBlob.type,
         });

--- a/apps/host/src/widgets/multi-image-add-button/multi-image-add-button.tsx
+++ b/apps/host/src/widgets/multi-image-add-button/multi-image-add-button.tsx
@@ -8,7 +8,7 @@ import * as styles from './multi-image-add-button.css';
 interface MultiImageAddButtonProps {
   currentCount: number;
   maxCount?: number;
-  onFilesChange: (files: File[]) => void;
+  onFilesChange: (files: File[]) => void | Promise<void>;
 }
 
 const MultiImageAddButton = ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@vanilla-extract/recipes':
         specifier: 'catalog:'
         version: 0.5.7(@vanilla-extract/css@1.18.0)
+      browser-image-compression:
+        specifier: ^2.0.2
+        version: 2.0.2
       firebase:
         specifier: ^12.8.0
         version: 12.8.0
@@ -2075,6 +2078,9 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
+  browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2546,6 +2552,7 @@ packages:
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -3492,6 +3499,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -5583,6 +5593,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  browser-image-compression@2.0.2:
+    dependencies:
+      uzip: 0.20201231.0
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.17
@@ -7170,6 +7184,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uzip@0.20201231.0: {}
 
   vite-node@3.2.4(@types/node@24.10.9)(terser@5.46.0):
     dependencies:


### PR DESCRIPTION
## 📌 Summary

- #351 

이미지 압축을 통한 공지사항 다중 이미지 업로드 속도 최적화를 진행합니다.

## 📚 Tasks

- `@amp/host` 경로에 `browser-image-compression` 라이브러리 설치
- 이미지 압축 로직 구현 및 적용

## 🔍 Describe

### 공지사항 다중 이미지 업로드 속도 최적화

#### 📌 현재 문제 상황
이번 1차 스프린트 기간에 **최대 5MB의 이미지를 최대 20장**까지 업로드 할 수 있도록 변경되었습니다. 이때, 무거운 원본 파일 전송으로 인해 업로드 대기 시간이 길어져 사용자 경험에 부정적 영향을 주고 있어 개선이 필요했습니다.

#### 📌 해결 방법

이미지 API 분리 등 여러 방법이 있겠지만, 우선 업로드 전 1차적으로 **클라이언트 단에서 이미지 압축을 도입**하기로 결정했습니다. 

파일 크기에 신경 쓸 필요 없이 고화질이 필수적인 서비스는 확대, 축소를 고려해 높은 해상도의 이미지를 필요로 하지만, 현재 저희 서비스는 고화질의 이미지가 필수적이지 않으며 오히려 **이미지 로딩 시간 증가와 트래픽 증가**를 발생시킵니다. 따라서 적절한 수준에서의 이미지 압축은 트래픽을 줄여 사용자 경험 개선에 도움이 될 수 있으리라 판단했습니다.

#### 📌 라이브러리 선택
이미지 압축을 위한 몇 가지 라이브러리를 검토했으나, `browser-image-compression`이 가장 적절하다고 판단하여 해당 라이브러리 도입을 결정했습니다. 

- **Web Worker 기본 지원** : 다중 이미지 압축 연산을 백그라운드로 넘겨, 압축 중에도 스크롤 및 타이핑 등 UI 조작이 가능합니다.
- **Promise 기반 병렬 처리** : `async/await` 문법을 지원하고, 병렬 처리 로직을 직관적으로 구현 가능합니다.
- **낮은 도입 장벽** : 도입 시 추가로 설정해야 하는 요소가 적고, 도입 장벽이 낮습니다.

#### 📌 image-compress 구현
압축과 관련한 순수 로직은 `@shared/libs`에 분리하여 캡슐화했습니다. 공지 이미지 외에도 공연 이미지 등에서 함수로 쉽게 사용 가능합니다. 라이브러리에서 제공하는 `imageCompression`을 활용하여 **압축과 동시에 webp 형식으로 변환**합니다.
```tsx
// 압축 조건 설정
const options = {
    maxSizeMB: 1,
    maxWidthOrHeight: 1920,
    useWebWorker: true,
    fileType: 'image/webp',
  };
```

압축 결과물은 파일 이름과 같은 메타데이터가 없는 `Blob` 형태로 반환되기 때문에, 서버 전송을 위해 `new File()` 생성자를 사용하여 **`File` 객체로 다시 변환**했습니다.
```tsx
const compressedBlob = await imageCompression(item.file, options);
const compressedFile = new File([compressedBlob], newFileName, {
     type: compressedBlob.type,
});
```

#### 📌 기존 이미지 업로드 로직(`use-image-upload`)에 적용

분리해둔 함수(`compressImageFiles`)를 활용하여 기존 이미지 로직에 적용했습니다.

사용자가 업로드하면 즉각적으로 미리보기가 보여야 하므로, 우선 **원본 파일로 배열 상태를 구성해 화면에 렌더링**합니다. 그 후 **백그라운드에서 압축이 끝나면, 해당 파일 객체만 교체**하도록 구현했습니다.


#### 📌 압축 중 공지 업로드 버튼 비활성화
폼 관련 로직을 전체적으로 관리하는 `use-notice-form` 내부에서는 압축 중을 나타내는 `isCompressing` 상태를 받아와서 버튼의 비활성화 상태를 결정하는 조건에 포함시켰습니다. 이를 통해 압축 중에는 공지 업로드가 불가능하도록 하여 오류를 방지할 수 있습니다.

<hr/>

### 개선 결과

현재 업로드 가능 최대 이미지 용량이 5MB 이하 최대 20장인 점을 감안하여, 2MB/3MB 이미지 각 10장씩 총 20장 업로드를 반복적으로 테스트 했습니다.

- **기존 소요 시간**: 평균 약 **7.24초**
- **개선 후 소요 시간**: 평균 약 **1.65초** (**약 77.2% 개선**)

기기 사양 및 네트워크 환경에 따라 차이가 있을 수 있습니다!


## 👀 To Reviewer

- 압축 후에도 공지 이미지 업로드가 잘 적용되는지 확인해주세요!
- 압축 정도가 적절한지 확인해주세요. (용량, 해상도 등)
- 추가 개선 사항이 있다면 알려주세요!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
