### PR TITLE
Fix(host): 공연 수정뷰 QA 반영

### DIFF
--- a/apps/host/src/features/event-edit/use-event-edit.ts
+++ b/apps/host/src/features/event-edit/use-event-edit.ts
@@ -1,12 +1,19 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { putFestival } from '@entities/event-edit/api/event-edit';
 
 import { ORGANIZERS_QUERY_KEY } from '@shared/constants/query-key';
 
 export const useFestivalUpdateMutation = (festivalId: number) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationKey: ORGANIZERS_QUERY_KEY.FESTIVAL_UPDATE(festivalId),
     mutationFn: (formData: FormData) => putFestival(festivalId, formData),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ORGANIZERS_QUERY_KEY.FESTIVAL_DETAIL(festivalId),
+      });
+    },
   });
 };

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -26,17 +26,6 @@ interface EventEditPageContentProps {
   festivalId: number;
 }
 
-const areSameCategoryIds = (prev: number[], next: number[]) => {
-  if (prev.length !== next.length) {
-    return false;
-  }
-
-  const sortedPrev = [...prev].sort((a, b) => a - b);
-  const sortedNext = [...next].sort((a, b) => a - b);
-
-  return sortedPrev.every((id, index) => id === sortedNext[index]);
-};
-
 const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
   const updateMutation = useFestivalUpdateMutation(festivalId);
 
@@ -136,16 +125,15 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
           return;
         }
 
-        const isCategoryChanged = !areSameCategoryIds(
-          initialValues.activeCategoryIds,
-          values.activeCategoryIds,
+        const hasDeletedCategory = initialValues.activeCategoryIds.some(
+          (id) => !values.activeCategoryIds.includes(id),
         );
 
         openConfirmModal({
-          title: isCategoryChanged
+          title: hasDeletedCategory
             ? '공지 카테고리를 수정하시겠어요?'
             : '수정하시겠어요?',
-          description: isCategoryChanged
+          description: hasDeletedCategory
             ? '카테고리를 수정하면\n해당 카테고리로 작성된 공지가 삭제돼요.'
             : undefined,
           values,

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -133,8 +133,8 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
 
         openConfirmModal({
           title: isCategoryChanged
-            ? '공연 카테고리를 수정하시겠어요?'
-            : '공연을 수정하시겠어요?',
+            ? '공지 카테고리를 수정하시겠어요?'
+            : '수정하시겠어요?',
           description: isCategoryChanged
             ? '카테고리를 수정하면\n해당 카테고리로 작성된 공지가 삭제돼요.'
             : undefined,

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -88,6 +88,7 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
           <Modal.Actions>
             <RectButton
               variant='secondary'
+              disabled={updateMutation.isPending}
               onClick={() => {
                 close();
                 unmount();

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -19,7 +19,7 @@ import { NAV_PATH } from '@shared/constants/path';
 interface ConfirmModalProps {
   title: string;
   description?: string;
-  onConfirm: () => Promise<boolean>;
+  values: EventFormSubmitValues;
 }
 
 interface EventEditPageContentProps {
@@ -60,28 +60,19 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
 
   const initialValues = toEventEditInitialValues(data);
 
-  const submitEdit = async (values: EventFormSubmitValues) => {
-    const formData = serializeUpdateFestivalFormData(values);
-
-    try {
-      await updateMutation.mutateAsync(formData);
-      navigate(NAV_PATH.noticeList(festivalId));
-      return true;
-    } catch {
-      toast.show('공연 수정에 실패했어요. 다시 시도해주세요.');
-      return false;
-    }
-  };
-
   const openConfirmModal = ({
     title,
     description,
-    onConfirm,
+    values,
   }: ConfirmModalProps) => {
     overlay.open(({ isOpen, close, unmount }) => (
       <Modal
         open={isOpen}
         onClose={() => {
+          if (updateMutation.isPending) {
+            return;
+          }
+
           close();
           unmount();
         }}
@@ -108,13 +99,22 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
             <RectButton
               variant='primary'
               disabled={updateMutation.isPending}
-              onClick={async () => {
-                const isSuccess = await onConfirm();
+              onClick={() => {
+                const formData = serializeUpdateFestivalFormData(values);
 
-                if (isSuccess) {
-                  close();
-                  unmount();
-                }
+                updateMutation.mutate(formData, {
+                  onSuccess: () => {
+                    close();
+                    unmount();
+                    navigate(NAV_PATH.noticeList(festivalId));
+                  },
+                  onError: () => {
+                    toast.show(
+                      '공연 수정에 실패했어요.',
+                      '잠시 후 다시 시도해 주세요.',
+                    );
+                  },
+                });
               }}
             >
               확인
@@ -147,7 +147,7 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
           description: isCategoryChanged
             ? '카테고리를 수정하면\n해당 카테고리로 작성된 공지가 삭제돼요.'
             : undefined,
-          onConfirm: () => submitEdit(values),
+          values,
         });
       }}
     />

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -60,14 +60,11 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
 
   const initialValues = toEventEditInitialValues(data);
 
-  const submitEdit = (values: EventFormSubmitValues) => {
+  const submitEdit = async (values: EventFormSubmitValues) => {
     const formData = serializeUpdateFestivalFormData(values);
 
-    updateMutation.mutate(formData, {
-      onSuccess: () => {
-        navigate(NAV_PATH.noticeList(festivalId));
-      },
-    });
+    await updateMutation.mutateAsync(formData);
+    navigate(NAV_PATH.noticeList(festivalId));
   };
 
   const openConfirmModal = ({

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { overlay } from 'overlay-kit';
 import { useNavigate, useParams } from 'react-router';
 
-import { Modal, RectButton } from '@amp/ads-ui';
+import { Modal, RectButton, toast } from '@amp/ads-ui';
 import { Loading } from '@amp/compositions';
 
 import EventForm from '@widgets/event-form/event-form';
@@ -19,7 +19,7 @@ import { NAV_PATH } from '@shared/constants/path';
 interface ConfirmModalProps {
   title: string;
   description?: string;
-  onConfirm: () => void;
+  onConfirm: () => Promise<boolean>;
 }
 
 interface EventEditPageContentProps {
@@ -63,8 +63,14 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
   const submitEdit = async (values: EventFormSubmitValues) => {
     const formData = serializeUpdateFestivalFormData(values);
 
-    await updateMutation.mutateAsync(formData);
-    navigate(NAV_PATH.noticeList(festivalId));
+    try {
+      await updateMutation.mutateAsync(formData);
+      navigate(NAV_PATH.noticeList(festivalId));
+      return true;
+    } catch {
+      toast.show('공연 수정에 실패했어요. 다시 시도해주세요.');
+      return false;
+    }
   };
 
   const openConfirmModal = ({
@@ -102,10 +108,13 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
             <RectButton
               variant='primary'
               disabled={updateMutation.isPending}
-              onClick={() => {
-                onConfirm();
-                close();
-                unmount();
+              onClick={async () => {
+                const isSuccess = await onConfirm();
+
+                if (isSuccess) {
+                  close();
+                  unmount();
+                }
               }}
             >
               확인

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -51,10 +51,6 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
     values: EventFormSubmitValues,
     closeModal: () => void,
   ) => {
-    if (updateMutation.isPending) {
-      return;
-    }
-
     const formData = serializeUpdateFestivalFormData(values);
 
     updateMutation.mutate(formData, {

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -47,6 +47,22 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
     return null;
   }
 
+  const handleConfirmEdit = (
+    values: EventFormSubmitValues,
+    closeModal: () => void,
+  ) => {
+    const formData = serializeUpdateFestivalFormData(values);
+
+    updateMutation.mutate(formData, {
+      onSuccess: () => {
+        closeModal();
+        navigate(NAV_PATH.noticeList(festivalId));
+      },
+      onError: () => {
+        toast.show('공연 수정에 실패했어요. 잠시 후 다시 시도해 주세요.');
+      },
+    });
+  };
   const initialValues = toEventEditInitialValues(data);
 
   const openConfirmModal = ({
@@ -90,20 +106,9 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
               variant='primary'
               disabled={updateMutation.isPending}
               onClick={() => {
-                const formData = serializeUpdateFestivalFormData(values);
-
-                updateMutation.mutate(formData, {
-                  onSuccess: () => {
-                    close();
-                    unmount();
-                    navigate(NAV_PATH.noticeList(festivalId));
-                  },
-                  onError: () => {
-                    toast.show(
-                      '공연 수정에 실패했어요.',
-                      '잠시 후 다시 시도해 주세요.',
-                    );
-                  },
+                handleConfirmEdit(values, () => {
+                  close();
+                  unmount();
                 });
               }}
             >

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -136,8 +136,8 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
 
         openConfirmModal({
           title: isCategoryChanged
-            ? '공지 카테고리를 수정하시겠어요?'
-            : '공지를 수정하시겠어요?',
+            ? '공연 카테고리를 수정하시겠어요?'
+            : '공연을 수정하시겠어요?',
           description: isCategoryChanged
             ? '카테고리를 수정하면\n해당 카테고리로 작성된 공지가 삭제돼요.'
             : undefined,

--- a/apps/host/src/pages/event-edit/event-edit.tsx
+++ b/apps/host/src/pages/event-edit/event-edit.tsx
@@ -51,6 +51,10 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
     values: EventFormSubmitValues,
     closeModal: () => void,
   ) => {
+    if (updateMutation.isPending) {
+      return;
+    }
+
     const formData = serializeUpdateFestivalFormData(values);
 
     updateMutation.mutate(formData, {
@@ -63,6 +67,7 @@ const EventEditPageContent = ({ festivalId }: EventEditPageContentProps) => {
       },
     });
   };
+
   const initialValues = toEventEditInitialValues(data);
 
   const openConfirmModal = ({

--- a/apps/host/src/widgets/home/festival-actions/festival-actions.tsx
+++ b/apps/host/src/widgets/home/festival-actions/festival-actions.tsx
@@ -27,9 +27,7 @@ const FestivalActionsView = ({
     <>
       {children}
       <OptionSheet open={isOptionSheetOpen} onClose={onCloseOptionSheet}>
-        <OptionSheet.Item onClick={onEdit}>
-          수정하기
-        </OptionSheet.Item>
+        <OptionSheet.Item onClick={onEdit}>수정하기</OptionSheet.Item>
         <OptionSheet.Item onClick={onOpenDeleteModal}>
           삭제하기
         </OptionSheet.Item>
@@ -37,10 +35,7 @@ const FestivalActionsView = ({
       <Modal open={isDeleteModalOpen} onClose={onCloseDeleteModal}>
         <Modal.Panel role='alertdialog'>
           <Modal.Content>
-            <Modal.Title>공연을 삭제할까요?</Modal.Title>
-            <Modal.Description>
-              삭제한 공연은 복구할 수 없어요.
-            </Modal.Description>
+            <Modal.Title>공연을 삭제하시겠어요?</Modal.Title>
           </Modal.Content>
           <Modal.Actions>
             <RectButton variant='secondary' onClick={onCloseDeleteModal}>


### PR DESCRIPTION
## 📌 Summary

> #353
공연 수정뷰 1차 스프린트 QA 반영

## 📚 Tasks

- 모달 텍스트 수정
- 공연 수정 후 상세 데이터 갱신 처리

## 🔍 Describe

### 문제...
1차 스프린트 QA 사항들을 반영했어요. (모달 텍스트 수정 / 공연 수정 후 상세 데이터 갱신 처리)

주요 이슈는 공연 수정 후에 다시 수정 페이지로 진입했을 때, `무대/부스 정보(AddedItem)`의 수정사항이 반영되지 않는다는 것이었어요.

### 원인...

확인 결과, 수정 요청은 성공하지만 이후 화면에서 최신 데이터를 안정적으로 GET 해오지 못해 AddedItem 목록이 최신 상태로 보이지 않는 것이 원인이었습니다.

이전 구조에서 수정 페이지는 `FESTIVAL_DETAIL(festivalId)` 쿼리를 통해 상세 데이터를 조회하고 있는데, 공연 수정 mutation 쪽에서는 성공 이후 해당 상세 데이터 쿼리를 갱신하거나 무효화하는 로직이 없었습니다. 

따라서 PUT 요청이 성공하더라도 React Query 캐시에 남아 있는 이전 데이터가 다음 진입 시 그대로 사용되어, 사용자가 수정이 반영되지 않은 것처럼 보이는 화면에 진입하게 되는 것이었어요.

### 해결....

해당 이슈 해결을 위해 `useFestivalUpdateMutation` 내부에 `queryClient.invalidateQueries` 를 추가했습니다. mutation 성공 시 `FESTIVAL_DETAIL(festivalId)` 쿼리를 무효화함으로써 수정 페이지로 다시 진입할 때 최신 서버 데이터를 조회하도록 수정했어요.

더불어 수정 성공 후 페이지 이동 전 invalidate가 끝나도록 `submitEdit` 부분도 정리했습니다. invalidate를 mutation 훅 내부에서 await 하고 이동하도록 정리하여, `수정 요청 성공 -> 관련 detail query invalidate -> 페이지 이동` 이라는 흐름이 더 명확해지도록 했어요. 


## 👀 To Reviewer
최신 상태가 잘 반영되는지 확인 부탁드려요! 
더 좋은 방법이 있다면 꼭!!! 리뷰 남겨주시면 감사하겠습니다... 🧎‍♀️

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
