### PR TITLE
Refactor(audience): 알림 구독 로직 수정

### DIFF
--- a/apps/audience/src/entities/auth/api/auth.ts
+++ b/apps/audience/src/entities/auth/api/auth.ts
@@ -1,6 +1,6 @@
 import { get } from '@amp/apis';
 
-import { AuthStatusResponse } from '@entities/auth/types/response';
+import type { AuthStatusResponse } from '@entities/auth/types/response';
 
 import { END_POINT } from '@shared/constants/end-point';
 

--- a/apps/audience/src/entities/auth/api/auth.ts
+++ b/apps/audience/src/entities/auth/api/auth.ts
@@ -1,0 +1,8 @@
+import { get } from '@amp/apis';
+
+import { AuthStatusResponse } from '@entities/auth/types/response';
+
+import { END_POINT } from '@shared/constants/end-point';
+
+export const getAuthStatus = () =>
+  get<AuthStatusResponse>(END_POINT.GET_AUTH_STATUS);

--- a/apps/audience/src/entities/auth/model/query-options.ts
+++ b/apps/audience/src/entities/auth/model/query-options.ts
@@ -1,0 +1,13 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { getAuthStatus } from '@entities/auth/api/auth';
+
+import { USERS_QUERY_KEY } from '@shared/constants/query-key';
+
+export const AUTH_QUERY_OPTIONS = {
+  AUTH_STATUS: () =>
+    queryOptions({
+      queryKey: USERS_QUERY_KEY.AUTH_STATUS(),
+      queryFn: () => getAuthStatus(),
+    }),
+} as const;

--- a/apps/audience/src/entities/auth/types/response.ts
+++ b/apps/audience/src/entities/auth/types/response.ts
@@ -1,5 +1,5 @@
 export interface AuthStatusResponse {
   authenticated: boolean;
   email: string;
-  userType: string;
+  userType: "AUDIENCE"| "ORGANIZER"| null;
 }

--- a/apps/audience/src/entities/auth/types/response.ts
+++ b/apps/audience/src/entities/auth/types/response.ts
@@ -1,0 +1,5 @@
+export interface AuthStatusResponse {
+  authenticated: boolean;
+  email: string;
+  userType: string;
+}

--- a/apps/audience/src/pages/notice-list/notice-list.tsx
+++ b/apps/audience/src/pages/notice-list/notice-list.tsx
@@ -18,9 +18,10 @@ import { formatDday } from '@amp/shared/utils';
 import { useToggleWishListMutation } from '@features/usecase/toggle-wishlist/use-toggle-wishlist-mutation';
 
 import { NOTICES_QUERY_OPTIONS } from '@entities/notice/model/query-options';
+import { USER_QUERY_OPTIONS } from '@entities/user/model/query-options';
 
 import { CATEGORY_CODE_BY_LABEL } from '@shared/constants/category-label';
-import { NAV_PATH } from '@shared/constants/path';
+import { NAV_PATH, ROUTE_PATH } from '@shared/constants/path';
 import { useNotificationsSubscribeMutation } from '@shared/hooks/use-festival-notification';
 import { useLiveStatus } from '@shared/hooks/use-live-status';
 import LiveStatusSheet from '@shared/ui/live-status-sheet/live-status-sheet';
@@ -41,6 +42,8 @@ const NoticeListPage = () => {
   const { data: bannerData } = useQuery(
     NOTICES_QUERY_OPTIONS.BANNER(festivalId),
   );
+
+  const { data: nicknameData } = useQuery(USER_QUERY_OPTIONS.NICKNAME());
 
   const { data } = useQuery(
     NOTICES_QUERY_OPTIONS.LIST(festivalId, {
@@ -98,6 +101,10 @@ const NoticeListPage = () => {
     : null;
 
   const handleAlertClick = () => {
+    if (nicknameData?.nickname === '관객') {
+      navigate(ROUTE_PATH.AUTH_REQUIRED);
+      return;
+    }
     overlay.open(({ isOpen, close, unmount }) => {
       const handleConfirmAlert = async () => {
         try {

--- a/apps/audience/src/pages/notice-list/notice-list.tsx
+++ b/apps/audience/src/pages/notice-list/notice-list.tsx
@@ -17,8 +17,8 @@ import { formatDday } from '@amp/shared/utils';
 
 import { useToggleWishListMutation } from '@features/usecase/toggle-wishlist/use-toggle-wishlist-mutation';
 
+import { AUTH_QUERY_OPTIONS } from '@entities/auth/model/query-options';
 import { NOTICES_QUERY_OPTIONS } from '@entities/notice/model/query-options';
-import { USER_QUERY_OPTIONS } from '@entities/user/model/query-options';
 
 import { CATEGORY_CODE_BY_LABEL } from '@shared/constants/category-label';
 import { NAV_PATH, ROUTE_PATH } from '@shared/constants/path';
@@ -43,7 +43,7 @@ const NoticeListPage = () => {
     NOTICES_QUERY_OPTIONS.BANNER(festivalId),
   );
 
-  const { data: nicknameData } = useQuery(USER_QUERY_OPTIONS.NICKNAME());
+  const { data: statusData } = useQuery(AUTH_QUERY_OPTIONS.AUTH_STATUS());
 
   const { data } = useQuery(
     NOTICES_QUERY_OPTIONS.LIST(festivalId, {
@@ -101,7 +101,7 @@ const NoticeListPage = () => {
     : null;
 
   const handleAlertClick = () => {
-    if (nicknameData?.nickname === '관객') {
+    if (statusData?.authenticated === false) {
       navigate(ROUTE_PATH.AUTH_REQUIRED);
       return;
     }

--- a/apps/audience/src/shared/constants/end-point.ts
+++ b/apps/audience/src/shared/constants/end-point.ts
@@ -37,4 +37,5 @@ export const END_POINT = {
   // Auth
   POST_LOGOUT: '/auth/logout',
   POST_ONBOARDING_COMPLETE: '/auth/onboarding/complete',
+  GET_AUTH_STATUS: '/auth/status'
 } as const;

--- a/apps/audience/src/shared/constants/end-point.ts
+++ b/apps/audience/src/shared/constants/end-point.ts
@@ -37,5 +37,5 @@ export const END_POINT = {
   // Auth
   POST_LOGOUT: '/auth/logout',
   POST_ONBOARDING_COMPLETE: '/auth/onboarding/complete',
-  GET_AUTH_STATUS: '/auth/status'
+  GET_AUTH_STATUS: '/auth/status',
 } as const;

--- a/apps/audience/src/shared/constants/query-key.ts
+++ b/apps/audience/src/shared/constants/query-key.ts
@@ -61,4 +61,5 @@ export const USERS_QUERY_KEY = {
   ],
 
   NICKNAME: () => [...USERS_QUERY_KEY.ALL, 'nickname'],
+  AUTH_STATUS: () => [...USERS_QUERY_KEY.ALL, 'auth-status'],
 } as const;


### PR DESCRIPTION
## 📌 Summary

> #355 

알림 구독 로직 수정

## 📚 Tasks

- 알림 구독 로직 수정

## 🔍 Describe

### 배경

현재 알림 구독 플로우는
알림 OS 모달 노출 → 토큰 발급 → 알림 구독 요청 순서로 동작하고 있습니다.

다만 전역 에러 핸들링(401, 403, 404)은 API 요청 이후에만 동작하기 때문에, 비로그인 사용자도 알림 구독 API 요청 전에 알림 OS 모달이 먼저 노출되는 문제가 있었습니다.

이에 알림 OS 모달 노출 전에 로그인 여부를 먼저 확인할 수 있도록 로직을 수정했습니다.

### 수정 내용

로그인 상태를 확인할 수 있는 API를 사용해, 알림 OS 모달 노출 전에 로그인 여부를 먼저 확인하도록 로직을 수정했습니다.  
비로그인 사용자라면 알림 OS 모달을 노출하지 않고 로그인 유도 페이지로 이동하도록 처리했습니다.

## 👀 To Reviewer
더 나은 개선 방향이 있다면 코멘트 부탁드립니다  👀
api 부분이 뒤죽박죽인 거 같아서,, 1차 스프린트 이후에 컨벤션 확실히 정해서 통일시켜보아요 !! ☺️




## 📸 Screenshot

https://github.com/user-attachments/assets/ff1ea4bb-3c6d-4d01-af6a-76fba5bd73db
